### PR TITLE
Set `website` on Gradle plugin

### DIFF
--- a/changelog/@unreleased/pr-7.v2.yml
+++ b/changelog/@unreleased/pr-7.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Set the website in the Gradle plugin declaration so publishing works
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/7

--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -20,6 +20,7 @@ gradlePlugin {
             id = 'com.palantir.suppressible-error-prone'
             displayName = 'Suppressible Error Prone'
             implementationClass = 'com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin'
+            website = 'https://github.com/palantir/suppressible-error-prone'
         }
     }
 }

--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -15,12 +15,15 @@ dependencies {
 }
 
 gradlePlugin {
+    website = 'https://github.com/palantir/suppressible-error-prone'
+    vcsUrl = 'https://github.com/palantir/suppressible-error-prone'
+
     plugins {
         suppressibleErrorProne {
             id = 'com.palantir.suppressible-error-prone'
             displayName = 'Suppressible Error Prone'
+            description = 'Extends the Gradle Error Prone Plugin and Error Prone itself to support automatically suppressing errors.'
             implementationClass = 'com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin'
-            website = 'https://github.com/palantir/suppressible-error-prone'
         }
     }
 }


### PR DESCRIPTION
## Before this PR
Publishing to the Gradle Plugin Portal has failed because [the website wasn't set](https://app.circleci.com/pipelines/github/palantir/suppressible-error-prone/47/workflows/a070c6ac-793d-4588-ba69-03575040b544/jobs/84/parallel-runs/0/steps/0-104?invite=true#step-104-18424_21).

## After this PR
==COMMIT_MSG==
Set the website in the Gradle plugin declaration so publishing works
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

