### PR TITLE
Support non-main source sets

### DIFF
--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    * Support non-main source sets (eg `test`)
+    * Provide a `compileAllErrorProne` task that depends on all the compile tasks with that have errorprone applied and enabled.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/8

--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -2,6 +2,6 @@ type: fix
 fix:
   description: |-
     * Support non-main source sets (eg `test`)
-    * Provide a `compileAllErrorProne` task that depends on all the compile tasks with that have errorprone applied and enabled.
+    * Provide a `compileAllErrorProne` task that depends on all the compile tasks that have errorprone applied and enabled.
   links:
   - https://github.com/palantir/suppressible-error-prone/pull/8

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorProneExtension.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorProneExtension.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -49,9 +48,9 @@ public abstract class SuppressibleErrorProneExtension {
     }
 
     public final void configureEachErrorProneOptions(Action<ErrorProneOptions> action) {
-        project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> ((ExtensionAware)
-                        javaCompile.getOptions())
-                .getExtensions()
-                .configure(ErrorProneOptions.class, action));
+        project.getTasks()
+                .withType(JavaCompile.class)
+                .configureEach(
+                        javaCompile -> SuppressibleErrorPronePlugin.configureErrorProneOptions(javaCompile, action));
     }
 }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -116,8 +116,6 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 return errorProneOptionsFor(javaCompile).getEnabled().get();
             }));
         });
-
-        System.out.println("ello");
     }
 
     private static void setupErrorProneArtifactTransform(Project project) {

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -26,8 +26,10 @@ import java.util.stream.Collectors;
 import net.ltgt.gradle.errorprone.CheckSeverity;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import net.ltgt.gradle.errorprone.ErrorPronePlugin;
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -84,11 +86,9 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
         project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
             configureJavaCompile(project, javaCompile);
 
-            ((ExtensionAware) javaCompile.getOptions())
-                    .getExtensions()
-                    .configure(ErrorProneOptions.class, errorProneOptions -> {
-                        configureErrorProneOptions(project, extension, javaCompile, errorProneOptions);
-                    });
+            configureErrorProneOptions(javaCompile, errorProneOptions -> {
+                setupErrorProneOptions(project, extension, javaCompile, errorProneOptions);
+            });
         });
 
         addAnnotationDependencyForSuppressingStage2(project, version);
@@ -110,6 +110,14 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 });
             });
         }
+
+        project.getTasks().register("compileAllErrorProne", Task.class, compileAll -> {
+            compileAll.dependsOn(project.getTasks().withType(JavaCompile.class).matching(javaCompile -> {
+                return errorProneOptionsFor(javaCompile).getEnabled().get();
+            }));
+        });
+
+        System.out.println("ello");
     }
 
     private static void setupErrorProneArtifactTransform(Project project) {
@@ -123,21 +131,25 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 .getAttributes()
                 .attribute(suppressible, false);
 
-        // It's the annotationProcessor configuration, not the errorprone that, is actually used by the compiler
-        // and so where we must put our transform. annotationProcessor extendsFrom errorprone.
-        project.getConfigurations().named("annotationProcessor").configure(errorProneConfiguration -> {
-            errorProneConfiguration
-                    .getDependencies()
-                    .add(project.getDependencies().create("com.google.errorprone:error_prone_check_api"));
-            errorProneConfiguration.getAttributes().attribute(suppressible, true);
-        });
-
         project.getDependencies().registerTransform(ModifyErrorProneCheckApi.class, spec -> {
             spec.getParameters().getSuppressionStage1().set(isSuppressingStageOne(project));
 
             Attribute<String> artifactType = Attribute.of("artifactType", String.class);
             spec.getFrom().attribute(suppressible, false).attribute(artifactType, "jar");
             spec.getTo().attribute(suppressible, true).attribute(artifactType, "jar");
+        });
+
+        project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
+            // It's the annotationProcessor configuration, not the errorprone that, is actually used by the compiler
+            // and so where we must put our transform. annotationProcessor extendsFrom errorprone.
+            project.getConfigurations()
+                    .named(sourceSet.getAnnotationProcessorConfigurationName())
+                    .configure(errorProneConfiguration -> {
+                        errorProneConfiguration
+                                .getDependencies()
+                                .add(project.getDependencies().create("com.google.errorprone:error_prone_check_api"));
+                        errorProneConfiguration.getAttributes().attribute(suppressible, true);
+                    });
         });
     }
 
@@ -148,7 +160,7 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
         }
     }
 
-    private void configureErrorProneOptions(
+    private void setupErrorProneOptions(
             Project project,
             SuppressibleErrorProneExtension extension,
             JavaCompile javaCompile,
@@ -239,6 +251,14 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                                         + version);
             });
         }
+    }
+
+    private static ErrorProneOptions errorProneOptionsFor(JavaCompile javaCompile) {
+        return ((ExtensionAware) javaCompile.getOptions()).getExtensions().getByType(ErrorProneOptions.class);
+    }
+
+    static void configureErrorProneOptions(JavaCompile javaCompile, Action<ErrorProneOptions> action) {
+        ((ExtensionAware) javaCompile.getOptions()).getExtensions().configure(ErrorProneOptions.class, action);
     }
 
     private static boolean isAnyKindOfPatching(Project project) {

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -137,6 +137,7 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
             spec.getTo().attribute(suppressible, true).attribute(artifactType, "jar");
         });
 
+        // We need to configure the transform in each source set as they each have their own compile task
         project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
             // It's the annotationProcessor configuration, not the errorprone that, is actually used by the compiler
             // and so where we must put our transform. annotationProcessor extendsFrom errorprone.

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -112,9 +112,10 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
         }
 
         project.getTasks().register("compileAllErrorProne", Task.class, compileAll -> {
-            compileAll.dependsOn(project.getTasks().withType(JavaCompile.class).matching(javaCompile -> {
-                return errorProneOptionsFor(javaCompile).getEnabled().get();
-            }));
+            compileAll.dependsOn(project.provider(
+                    () -> project.getTasks().withType(JavaCompile.class).matching(javaCompile -> {
+                        return errorProneOptionsFor(javaCompile).getEnabled().get();
+                    })));
         });
     }
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -27,7 +27,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     File sourceSetRoot
     File mainSourceSet
     File otherSourceSet
-    File appJava
 
     def setupSpec() {
         FileUtils.deleteDirectory(nebulatestSourceSets)
@@ -37,7 +36,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         sourceSetRoot = new File(nebulatestSourceSets, projectDir.name)
         mainSourceSet = directory('src/main/java', sourceSetRoot)
         otherSourceSet = directory('src/other/java', sourceSetRoot)
-        appJava = file('app/App.java', mainSourceSet)
 
         // language=Gradle
         buildFile << '''
@@ -85,6 +83,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
         buildFile << """
             sourceSets.main.java.srcDirs('${projectDir.relativePath(mainSourceSet)}')
+            sourceSets.other.java.srcDirs('${projectDir.relativePath(otherSourceSet)}')
         """.stripIndent(true)
 
         file('gradle.properties') << '''
@@ -95,7 +94,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
     def 'reports a failing error prone'() {
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -117,7 +116,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
         when:
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
@@ -144,14 +143,14 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
 
         when:
-        def sourceSet1 = new File(sourceSetRoot, '/src/generated')
-        def sourceSet2 = new File(sourceSetRoot, '/build/somePlace')
+        def sourceDir1 = new File(sourceSetRoot, '/src/generated')
+        def sourceDir2 = new File(sourceSetRoot, '/build/somePlace')
 
-        writeJavaSourceFile(erroringCode, sourceSet1)
-        writeJavaSourceFile(erroringCode.replace('App', 'App2'), sourceSet2)
+        writeJavaSourceFile(erroringCode, sourceDir1)
+        writeJavaSourceFile(erroringCode.replace('App', 'App2'), sourceDir2)
 
         buildFile << """
-            sourceSets.main.java.srcDirs('${projectDir.relativePath(sourceSet1)}', '${projectDir.relativePath(sourceSet2)}')
+            sourceSets.main.java.srcDirs('${projectDir.relativePath(sourceDir1)}', '${projectDir.relativePath(sourceDir2)}')
         """.stripIndent(true)
 
         then:
@@ -167,7 +166,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -182,7 +181,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         then:
         runTasksSuccessfully('compileAllErrorProne')
 
-        appJava.text.contains('Arrays.toString(new int[3])')
+        appJavaTextContains('Arrays.toString(new int[3])')
     }
 
     def 'does not apply patches for a check if not added to the patchChecks list'() {
@@ -195,7 +194,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -208,7 +207,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJava.text.contains('new int[3].toString()')
+        appJavaTextContains('new int[3].toString()')
     }
 
     def 'does not apply patches if there is nothing in patchChecks set'() {
@@ -220,7 +219,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -235,7 +234,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
         then:
         stderr.contains('[ArrayToString]')
-        appJava.text.contains('new int[3].toString()')
+        appJavaTextContains('new int[3].toString()')
     }
 
     def 'does not apply patches for check that was explicitly disabled'() {
@@ -251,7 +250,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -264,12 +263,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJava.text.contains('new int[3].toString()')
+        appJavaTextContains('new int[3].toString()')
     }
 
     def 'can patch specific checks using -PerrorProneApply'() {
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -283,14 +282,13 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply=ArrayToString,ArrayEquals')
 
         then:
-        def patchedSource = appJava.text
-        patchedSource.contains('Arrays.toString(new int[3])')
-        patchedSource.contains('Arrays.equals(new int[2], new int[1])')
+        appJavaTextContains('Arrays.toString(new int[3])')
+        appJavaTextContains('Arrays.equals(new int[2], new int[1])')
     }
 
     def 'can suppress a failing check (even if not in patchChecks set)'() {
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -306,12 +304,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         then:
         runTasksSuccessfully('compileAllErrorProne')
 
-        appJava.text.contains('@SuppressWarnings(\"for-rollout:ArrayToString\")')
+        appJavaTextContains('@SuppressWarnings(\"for-rollout:ArrayToString\")')
     }
 
     def 'demonstrate suppressions on different source elements'() {
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public final String field = new int[3].toString();
@@ -341,7 +339,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne')
 
         // language=Java
-        appJava.text == '''
+        appJavaTextEquals '''
             package app;
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
@@ -375,7 +373,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         // than where the diagnostic description was produced.
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public void variables() {
@@ -392,7 +390,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne')
 
         // language=Java
-        appJava.text == '''
+        appJavaTextEquals '''
             package app;
             public final class App {
                 public void variables() {
@@ -406,7 +404,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     def 'can disable errorprone using property'() {
         when:
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -435,10 +433,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             suppressibleErrorProne {
                 patchChecks.add('ArrayToString')
             }
+            
+            println 'other src:' + sourceSets.other.allSource.srcDirs
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -452,7 +452,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJava.text.contains('Arrays.toString(new int[3])')
+        appJavaTextContains('Arrays.toString(new int[3])')
     }
 
     def 'can conditionally add patch checks'() {
@@ -468,7 +468,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -482,9 +482,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
 
         then:
-        def patchedText = appJava.text
-        patchedText.contains('Arrays.toString(new int[3])')
-        patchedText.contains('new int[2].equals(new int[1])')
+        appJavaTextContains('Arrays.toString(new int[3])')
+        appJavaTextContains('new int[2].equals(new int[1])')
     }
 
     def 'IfModuleIsUsed works properly'() {
@@ -501,11 +500,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             dependencies {
                 // Depends on jackson-core
                 implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+                otherImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
             }
         '''.stripIndent(true)
 
         // language=Java
-        writeJavaSourceFile '''
+        writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
                 public static void main(String[] args) {
@@ -518,9 +518,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        def patchedText = appJava.text
-        patchedText.contains('Arrays.toString(new int[3])')
-        patchedText.contains('new int[2].equals(new int[1])')
+        appJavaTextContains('Arrays.toString(new int[3])')
+        appJavaTextContains('new int[2].equals(new int[1])')
     }
 
     def 'compileAllErrorProne only depends on compile tasks with errorprone enabled'() {
@@ -555,8 +554,19 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         return super.runTasks(strings)
     }
 
-    @Override
-    void writeJavaSourceFile(String source) {
-        super.writeJavaSourceFile(source, sourceSetRoot)
+
+    void writeJavaSourceFileToSourceSets(String source) {
+        super.writeJavaSourceFile(source, 'src/main/java', sourceSetRoot)
+        super.writeJavaSourceFile(source, 'src/other/java', sourceSetRoot)
+    }
+
+    void appJavaTextContains(String substring) {
+        assert file('app/App.java', mainSourceSet).text.contains(substring)
+        assert file('app/App.java', otherSourceSet).text.contains(substring)
+    }
+
+    void appJavaTextEquals(String substring) {
+        assert file('app/App.java', mainSourceSet).text == substring
+        assert file('app/App.java', otherSourceSet).text == substring
     }
 }

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -26,6 +26,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     static File nebulatestSourceSets = new File('nebulatestSourceSets/' + SuppressibleErrorPronePluginIntegrationTest.class.simpleName)
     File sourceSetRoot
     File mainSourceSet
+    File otherSourceSet
     File appJava
 
     def setupSpec() {
@@ -35,6 +36,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     def setup() {
         sourceSetRoot = new File(nebulatestSourceSets, projectDir.name)
         mainSourceSet = directory('src/main/java', sourceSetRoot)
+        otherSourceSet = directory('src/other/java', sourceSetRoot)
         appJava = file('app/App.java', mainSourceSet)
 
         // language=Gradle
@@ -48,6 +50,10 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 // as jars to the various configurations. We make sure to publish these to maven local before the
                 // test task runs. 
                 mavenLocal()
+            }
+            
+            sourceSets {
+                other
             }
             
             dependencies {
@@ -99,7 +105,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        def stderr = runTasksWithFailure('compileJava').standardError
+        def stderr = runTasksWithFailure('compileAllErrorProne').standardError
 
         then:
         stderr.contains('[ArrayToString]')
@@ -122,7 +128,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         then:
-        runTasksSuccessfully('compileJava')
+        runTasksSuccessfully('compileAllErrorProne')
     }
 
     def 'ensure error prone checks are disabled in generated code'() {
@@ -149,7 +155,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         """.stripIndent(true)
 
         then:
-        runTasksSuccessfully('compileJava')
+        runTasksSuccessfully('compileAllErrorProne')
     }
 
     def 'can apply patches for a check if added to the patchChecks list'() {
@@ -171,10 +177,10 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        runTasksSuccessfully('compileJava')
+        runTasksSuccessfully('compileAllErrorProne')
 
         appJava.text.contains('Arrays.toString(new int[3])')
     }
@@ -199,7 +205,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
         appJava.text.contains('new int[3].toString()')
@@ -225,7 +231,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
         when:
         // Doesn't actually do any patching as the set is empty. It just does a normal compile that fails.
-        def stderr = runTasksWithFailure('compileJava', '-PerrorProneApply').standardError
+        def stderr = runTasksWithFailure('compileAllErrorProne', '-PerrorProneApply').standardError
 
         then:
         stderr.contains('[ArrayToString]')
@@ -255,7 +261,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
         appJava.text.contains('new int[3].toString()')
@@ -274,7 +280,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply=ArrayToString,ArrayEquals')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply=ArrayToString,ArrayEquals')
 
         then:
         def patchedSource = appJava.text
@@ -294,11 +300,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneSuppressStage1')
-        runTasksSuccessfully('compileJava', '-PerrorProneSuppressStage2')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage1')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage2')
 
         then:
-        runTasksSuccessfully('compileJava')
+        runTasksSuccessfully('compileAllErrorProne')
 
         appJava.text.contains('@SuppressWarnings(\"for-rollout:ArrayToString\")')
     }
@@ -328,11 +334,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneSuppressStage1')
-        runTasksSuccessfully('compileJava', '-PerrorProneSuppressStage2')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage1')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage2')
 
         then:
-        runTasksSuccessfully('compileJava')
+        runTasksSuccessfully('compileAllErrorProne')
 
         // language=Java
         appJava.text == '''
@@ -379,11 +385,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneSuppressStage1')
-        runTasksSuccessfully('compileJava', '-PerrorProneSuppressStage2')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage1')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage2')
 
         then:
-        runTasksSuccessfully('compileJava')
+        runTasksSuccessfully('compileAllErrorProne')
 
         // language=Java
         appJava.text == '''
@@ -410,8 +416,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         then:
-        runTasksSuccessfully('compileJava', '-PerrorProneDisable')
-        runTasksSuccessfully('compileJava', '-Pcom.palantir.baseline-error-prone.disable')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneDisable')
+        runTasksSuccessfully('compileAllErrorProne', '-Pcom.palantir.baseline-error-prone.disable')
     }
 
     def 'should be able to refactor near usages of deprecated methods'() {
@@ -443,7 +449,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
         appJava.text.contains('Arrays.toString(new int[3])')
@@ -472,7 +478,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             }
         '''.stripIndent(true)
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
 
         then:
@@ -509,12 +515,29 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             }
         '''.stripIndent(true)
         when:
-        runTasksSuccessfully('compileJava', '-PerrorProneApply')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
         def patchedText = appJava.text
         patchedText.contains('Arrays.toString(new int[3])')
         patchedText.contains('new int[2].equals(new int[1])')
+    }
+
+    def 'compileAllErrorProne only depends on compile tasks with errorprone enabled'() {
+        // language=Gradle
+        buildFile << '''
+            tasks.named('compileTestJava').configure {
+                options.errorprone.enabled = false
+            }
+        '''.stripIndent(true)
+
+        when:
+        def stdout = runTasksSuccessfully('compileAllErrorProne', '--dry-run').standardOutput
+
+        then:
+        stdout.contains(':compileJava SKIPPED')
+        !stdout.contains(':compileTestJava SKIPPED')
+        stdout.contains(':compileOtherJava SKIPPED')
     }
 
     @Override

--- a/readme.md
+++ b/readme.md
@@ -80,24 +80,30 @@ public final class MyPlugin implements Plugin<Project> {
 }
 ```
 
+This plugin adds a marker task you can handily use that will run all the compile tasks with that have errorprone applied and enabled:
+
+```
+./gradlew compileAllErrorProne
+```
+
 To actually suppress all the current failures, you need to run compilation twice:
 
 ```
-./gradlew classes testClasses -PerrorProneSuppressStage1
-./gradlew classes testClasses -PerrorProneSuppressStage2
+./gradlew compileAllErrorProne -PerrorProneSuppressStage1
+./gradlew compileAllErrorProne -PerrorProneSuppressStage2
 ```
 
 If rolling out automatically to lots of repos, we'd recommend running the fixes first before suppressing:
 
 ```
-./gradlew classes testClasses -PerrorProneApply
+./gradlew compileAllErrorProne -PerrorProneApply
 ```
 
 You can also run fixes for individual checks:
 
 ```
-./gradlew classes testClasses -PerrorProneApply=Check
-./gradlew classes testClasses -PerrorProneApply=Check,OtherCheck
+./gradlew compileAllErrorProne -PerrorProneApply=Check
+./gradlew compileAllErrorProne -PerrorProneApply=Check,OtherCheck
 ```
 
 Errorprone can be disabled by using the `-PerrorProneDisable` property.


### PR DESCRIPTION
## Before this PR
In #6, we allowed errorprones to be automatically suppressed. However, this only worked for the `main` source set. Any other sourceset (like `test`) did not get this feature.

## After this PR
==COMMIT_MSG==
* Support non-main source sets (eg `test`)
* Provide a `compileAllErrorProne` task that depends on all the compile tasks with that have errorprone applied and enabled.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

