### PR TITLE
Set tags too to try to fix Gradle plugin portal publish

### DIFF
--- a/changelog/@unreleased/pr-9.v2.yml
+++ b/changelog/@unreleased/pr-9.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Set tags too to try to fix Gradle plugin portal publish
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/9

--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -23,6 +23,7 @@ gradlePlugin {
             id = 'com.palantir.suppressible-error-prone'
             displayName = 'Suppressible Error Prone'
             description = 'Extends the Gradle Error Prone Plugin and Error Prone itself to support automatically suppressing errors.'
+            tags = ['error-prone', 'javac', 'suppression']
             implementationClass = 'com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin'
         }
     }


### PR DESCRIPTION
## Before this PR
Publish is still failing as [we didn't set `tags`](https://app.circleci.com/pipelines/github/palantir/suppressible-error-prone/61/workflows/d1536002-97e2-4bc0-9126-4a133710febb/jobs/111?invite=true#step-104-18424_60).

## After this PR
==COMMIT_MSG==
Set tags too to try to fix Gradle plugin portal publish
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

