### PR TITLE
Don't fail to suppress on non-class type definitions (interfaces, enums, records etc)

### DIFF
--- a/changelog/@unreleased/pr-14.v2.yml
+++ b/changelog/@unreleased/pr-14.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Don't fail to suppress on non-class type definitions (interfaces, enums,
+    records etc)
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/14

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -350,7 +350,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 public final String field = new int[3].toString();
                 
                 @SuppressWarnings("for-rollout:ArrayToString")
-                App() {
+                public App() {
                     System.out.println(new int[3].toString());
                 }
                 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -69,7 +69,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 //   5. Run the tests as well
                 // If the variable below is true the tests will fail as the compilation process will try to
                 // attach to a non-existent debugger. Set it to false before you push any code.
-                boolean debuggingErrorPrones = true
+                boolean debuggingErrorPrones = false
                 if (debuggingErrorPrones) {
                     it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
                         @Override
@@ -314,6 +314,10 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             public final class App {
                 public final String field = new int[3].toString();
 
+                public App() {
+                    System.out.println(new int[3].toString());
+                }
+                
                 public void method() {
                     System.out.println(new int[3].toString());
                 }
@@ -344,7 +348,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public final String field = new int[3].toString();
-
+                
+                @SuppressWarnings("for-rollout:ArrayToString")
+                App() {
+                    System.out.println(new int[3].toString());
+                }
+                
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public void method() {
                     System.out.println(new int[3].toString());

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -69,7 +69,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 //   5. Run the tests as well
                 // If the variable below is true the tests will fail as the compilation process will try to
                 // attach to a non-existent debugger. Set it to false before you push any code.
-                boolean debuggingErrorPrones = false
+                boolean debuggingErrorPrones = true
                 if (debuggingErrorPrones) {
                     it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
                         @Override
@@ -398,6 +398,33 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                     String variable;
                 }
             }
+        '''.stripIndent(true)
+    }
+
+    def 'supports suppressing errorprone checks on classes, interfaces, records, enums, etc'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                static class exports {}
+                interface opens {}
+                record provides(int cat) {}
+                enum to {;}
+                @interface module {}
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage1')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage2')
+
+        then:
+        runTasksSuccessfully('compileAllErrorProne')
+
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App { }
         '''.stripIndent(true)
     }
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -424,7 +424,18 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         // language=Java
         appJavaTextEquals '''
             package app;
-            public final class App { }
+            public final class App {
+                @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
+                static class exports {}
+                @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
+                interface opens {}
+                @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
+                record provides(int cat) {}
+                @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
+                enum to {;}
+                @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
+                @interface module {}
+            }
         '''.stripIndent(true)
     }
 

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -52,12 +52,18 @@ public final class VisitorStateModifications {
                 .dropWhile(path -> !suppressibleKind(path.getLeaf().getKind()))
                 .findFirst()
                 .orElseThrow(() -> {
-                    return new RuntimeException("Can't find any source element on the TreePath to the error to "
-                            + "place a @SuppressWarnings on. This is a bug with suppressible-error-prone. "
-                            + "The path to the error is:\n\n"
-                            + StreamSupport.stream(pathToActualError.spliterator(), false)
-                                    .map(tree -> tree.getKind().name() + "\n===========================\n" + tree)
-                                    .collect(Collectors.joining("\n\n")));
+                    return new RuntimeException(
+                            """
+                            Can't find any source element on the TreePath to the error to \
+                            place a @SuppressWarnings on. This is a bug with suppressible-error-prone.
+                            The path to the error is:
+
+
+                            """
+                                    + StreamSupport.stream(pathToActualError.spliterator(), false)
+                                            .map(tree ->
+                                                    tree.getKind().name() + "\n===========================\n" + tree)
+                                            .collect(Collectors.joining("\n\n")));
                 })
                 .getLeaf();
 

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -53,7 +53,7 @@ public final class VisitorStateModifications {
                 .findFirst()
                 .orElseThrow(() -> {
                     return new RuntimeException("Can't find any source element on the TreePath to the error to "
-                            + "place a @SuppressWarnings on. This is a bug an with suppressible-error-prone. "
+                            + "place a @SuppressWarnings on. This is a bug with suppressible-error-prone. "
                             + "The path to the error is:\n\n"
                             + StreamSupport.stream(pathToActualError.spliterator(), false)
                                     .map(tree -> tree.getKind().name() + "\n===========================\n" + tree)

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -19,6 +19,7 @@ package com.palantir.suppressibleerrorprone;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -80,9 +81,15 @@ public final class VisitorStateModifications {
     private VisitorStateModifications() {}
 
     private static boolean suppressibleKind(Tree.Kind kind) {
+        // This covers all type definitions eg class, interface, enum, record, annotation, future kinds
+        // of class-like type definitions.
+        if (kind.asInterface().equals(ClassTree.class)) {
+            return true;
+        }
+
         // VARIABLE includes fields
         return switch (kind) {
-            case CLASS, METHOD, VARIABLE -> true;
+            case METHOD, VARIABLE -> true;
             default -> false;
         };
     }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -53,7 +53,7 @@ public final class VisitorStateModifications {
                 .findFirst()
                 .orElseThrow(() -> {
                     return new RuntimeException("Can't find any source element on the TreePath to the error to "
-                            + "place a @SuppressWarnings on. This is a bug an issues with suppressible-error-prone. "
+                            + "place a @SuppressWarnings on. This is a bug an with suppressible-error-prone. "
                             + "The path to the error is:\n\n"
                             + StreamSupport.stream(pathToActualError.spliterator(), false)
                                     .map(tree -> tree.getKind().name() + "\n===========================\n" + tree)

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -45,10 +45,13 @@ public final class VisitorStateModifications {
         TreePath pathToActualError =
                 TreePath.getPath(visitorState.getPath().getCompilationUnit(), description.position.getTree());
 
-        Tree firstSuppressibleParent = Stream.iterate(pathToActualError, TreePath::getParentPath)
+        Tree firstSuppressibleParent = Stream.iterate(
+                        pathToActualError, treePath -> treePath.getParentPath() != null, TreePath::getParentPath)
                 .dropWhile(path -> !suppressibleKind(path.getLeaf().getKind()))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("Can't find anything we can suppress"))
+                .orElseThrow(() -> new RuntimeException("Can't find any source element on the TreePath to the error to "
+                        + "place a @SuppressWarnings on. This is a bug an issues with suppressible-error-prone. "
+                        + "The path to the error is:\n\n" + pathToActualError))
                 .getLeaf();
 
         // Guess the indent if we can't find it for some reason. Formatter will fix.
@@ -84,7 +87,7 @@ public final class VisitorStateModifications {
         // This covers all type definitions eg class, interface, enum, record, annotation, future kinds
         // of class-like type definitions.
         if (kind.asInterface().equals(ClassTree.class)) {
-            return true;
+            return false;
         }
 
         // VARIABLE includes fields

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -26,7 +26,9 @@ import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class VisitorStateModifications {
 
@@ -49,9 +51,14 @@ public final class VisitorStateModifications {
                         pathToActualError, treePath -> treePath.getParentPath() != null, TreePath::getParentPath)
                 .dropWhile(path -> !suppressibleKind(path.getLeaf().getKind()))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("Can't find any source element on the TreePath to the error to "
-                        + "place a @SuppressWarnings on. This is a bug an issues with suppressible-error-prone. "
-                        + "The path to the error is:\n\n" + pathToActualError))
+                .orElseThrow(() -> {
+                    return new RuntimeException("Can't find any source element on the TreePath to the error to "
+                            + "place a @SuppressWarnings on. This is a bug an issues with suppressible-error-prone. "
+                            + "The path to the error is:\n\n"
+                            + StreamSupport.stream(pathToActualError.spliterator(), false)
+                                    .map(tree -> tree.getKind().name() + "\n===========================\n" + tree)
+                                    .collect(Collectors.joining("\n\n")));
+                })
                 .getLeaf();
 
         // Guess the indent if we can't find it for some reason. Formatter will fix.

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -94,7 +94,7 @@ public final class VisitorStateModifications {
         // This covers all type definitions eg class, interface, enum, record, annotation, future kinds
         // of class-like type definitions.
         if (kind.asInterface().equals(ClassTree.class)) {
-            return false;
+            return true;
         }
 
         // VARIABLE includes fields


### PR DESCRIPTION
## Before this PR
Suppressing fails when there is an errorprone error raised on an interface, enum, record etc (anything that isn't a class):

```
public interface InterfaceType {
       ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.31.0
     BugPattern: SafeLoggingPropagation
     Stack Trace:
     java.lang.NullPointerException: Cannot invoke "com.sun.source.util.TreePath.getLeaf()" because "path" is null
        at com.palantir.suppressibleerrorprone.VisitorStateModifications.lambda$interceptDescription$0(VisitorStateModifications.java:44)
```

This is because we never find a top level type we can suppress, as we didn't think of anything but class as suppressible.

## After this PR
==COMMIT_MSG==
Don't fail to suppress on non-class type definitions (interfaces, enums, records etc)
==COMMIT_MSG==

I've also significantly improved the error message when this does go wrong:

```
public interface InterfaceType {
       ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.31.0
     BugPattern: SafeLoggingPropagation
     Stack Trace:
     java.lang.RuntimeException: Can't find any source element on the TreePath to the error to place a @SuppressWarnings on. This is a bug an issues with suppressible-error-prone. The path to the error is:
  
  ===========================
  INTERFACE
  ===========================
  
  public interface InterfaceType {
      // ...
  }
  
  ===========================
  COMPILATION_UNIT
  ===========================
  package app;
  
  // ...
  
  public interface InterfaceType {
      // ...
  }
        at com.palantir.suppressibleerrorprone.VisitorStateModifications.lambda$interceptDescription$3(VisitorStateModifications.java:57)

```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

