### PR TITLE
Support errorprone being enabled by setting `com.palantir.baseline-error-prone.disable=false`

### DIFF
--- a/changelog/@unreleased/pr-17.v2.yml
+++ b/changelog/@unreleased/pr-17.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ensure we match the behaviour of `com.palantir.baseline-error-prone.disable`
+    from baseline.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/17

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -290,10 +290,6 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
 
     private static boolean isDisabledViaLegacyBaselineProperty(Project project) {
         Object disable = project.findProperty(ERROR_PRONE_BASELINE_DISABLE);
-        if (disable == null) {
-            return false;
-        } else {
-            return !disable.equals("false");
-        }
+        return disable != null && !disable.equals("false");
     }
 }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -20,7 +20,6 @@ import com.palantir.gradle.suppressibleerrorprone.transform.ModifyErrorProneChec
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import net.ltgt.gradle.errorprone.CheckSeverity;
@@ -40,10 +39,10 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
     private static final String SUPPRESS_STAGE_ONE = "errorProneSuppressStage1";
     private static final String SUPPRESS_STAGE_TWO = "errorProneSuppressStage2";
     private static final String ERROR_PRONE_APPLY = "errorProneApply";
-    private static final Set<String> ERROR_PRONE_DISABLE = Set.of(
-            "errorProneDisable",
-            // This is only here for backcompat from when all the errorprone code lived in baseline
-            "com.palantir.baseline-error-prone.disable");
+    private static final String ERROR_PRONE_DISABLE = "errorProneDisable";
+
+    // This is only here for backcompat from when all the errorprone code lived in baseline
+    private static final String ERROR_PRONE_BASELINE_DISABLE = "com.palantir.baseline-error-prone.disable";
 
     @Override
     public void apply(Project project) {
@@ -166,8 +165,11 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {
 
-        errorProneOptions.getEnabled().set(project.provider(() -> ERROR_PRONE_DISABLE.stream()
-                .noneMatch(project::hasProperty)));
+        errorProneOptions.getEnabled().set(project.provider(() -> {
+            boolean newDisable = project.hasProperty(ERROR_PRONE_DISABLE);
+            boolean oldDisable = isDisabledViaLegacyBaselineProperty(project);
+            return !(newDisable || oldDisable);
+        }));
 
         // This doesn't seem to do what you'd expect: disabling the checks in the generated code. But it was enabled
         // when this code lived in baseline, so we'll keep it enabled.
@@ -284,5 +286,14 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
 
         // language=RegExp
         return ".*/(build|generated_.*[sS]rc|src/generated.*)/.*";
+    }
+
+    private static boolean isDisabledViaLegacyBaselineProperty(Project project) {
+        Object disable = project.findProperty(ERROR_PRONE_BASELINE_DISABLE);
+        if (disable == null) {
+            return false;
+        } else {
+            return !disable.equals("false");
+        }
     }
 }

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -449,7 +449,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     }
 
     def 'can disable errorprone using property'() {
-        when: 'there is some that will fail an errorprone'
+        when: 'there is java code some that will fail an errorprone during compilation'
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -449,7 +449,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     }
 
     def 'can disable errorprone using property'() {
-        when:
+        when: 'there is some that will fail an errorprone'
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
@@ -460,9 +460,13 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             }
         '''.stripIndent(true)
 
-        then:
+        then: 'compilation succeeds when errorprone is disabled'
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneDisable')
         runTasksSuccessfully('compileAllErrorProne', '-Pcom.palantir.baseline-error-prone.disable')
+        runTasksSuccessfully('compileAllErrorProne', '-Pcom.palantir.baseline-error-prone.disable=true')
+
+        then: 'compilation fails the legacy baseline errorprone disable property is set to false'
+        runTasksWithFailure('compileAllErrorProne', '-Pcom.palantir.baseline-error-prone.disable=false')
     }
 
     def 'should be able to refactor near usages of deprecated methods'() {


### PR DESCRIPTION
## Before this PR
This behaviour has changed from baseline, which was [this snippet](https://github.com/palantir/gradle-baseline/blob/addba397fceeced9d284c715b9588257afa6f38e/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java#L327-L334).

Causing a test to fail on https://github.com/palantir/gradle-baseline/pull/2944

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure we match the behaviour of `com.palantir.baseline-error-prone.disable` from baseline.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

