### PR TITLE
Publish libraries that are run during compilation at target level 11

### DIFF
--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Libraries from this repo that are used in compilation (`suppressible-error-prone`,
+    `suppressible-error-prone-annotations`) are now targeted at JDK 11 rather than
+    17.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/22

--- a/suppressible-error-prone-annotations/build.gradle
+++ b/suppressible-error-prone-annotations/build.gradle
@@ -1,2 +1,9 @@
 apply plugin: 'java-library'
 apply plugin: 'com.palantir.external-publish-jar'
+
+// Unfortunately, a few internal products are still compiling with Java 11. Remove this entirely once this is no
+// longer the case.
+javaVersion {
+    target = 11
+    runtime = 17
+}

--- a/suppressible-error-prone/build.gradle
+++ b/suppressible-error-prone/build.gradle
@@ -24,3 +24,11 @@ moduleJvmArgs {
             'jdk.compiler/com.sun.tools.javac.tree',
             'jdk.compiler/com.sun.tools.javac.util')
 }
+
+// Unfortunately, a few internal products are still compiling with Java 11. Remove this entirely once this is no
+// longer the case.
+javaVersion {
+    target = 11
+    runtime = 17
+}
+

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesce.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesce.java
@@ -84,7 +84,7 @@ public final class SuppressWarningsCoalesce extends BugChecker
                     return annotationName.contentEquals("SuppressWarnings")
                             || annotationName.contentEquals("RepeatableSuppressWarnings");
                 })
-                .toList();
+                .collect(Collectors.toList());
 
         if (suppressWarnings.isEmpty()) {
             return Description.NO_MATCH;
@@ -131,17 +131,20 @@ public final class SuppressWarningsCoalesce extends BugChecker
 
     private static Stream<String> annotationStringValues(AnnotationTree annotation) {
         return annotation.getArguments().stream().flatMap(arg -> {
-            if (!(arg instanceof AssignmentTree assignment)) {
+            if (!(arg instanceof AssignmentTree)) {
                 return Stream.empty();
             }
+            AssignmentTree assignment = (AssignmentTree) arg;
 
             ExpressionTree expression = assignment.getExpression();
 
-            if (expression instanceof LiteralTree literalTree) {
+            if (expression instanceof LiteralTree) {
+                LiteralTree literalTree = (LiteralTree) expression;
                 return Stream.of((String) literalTree.getValue());
             }
 
-            if (expression instanceof NewArrayTree newArray) {
+            if (expression instanceof NewArrayTree) {
+                NewArrayTree newArray = (NewArrayTree) expression;
                 return newArray.getInitializers().stream()
                         .map(LiteralTree.class::cast)
                         .map(LiteralTree::getValue)

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -48,18 +48,14 @@ public final class VisitorStateModifications {
                 .dropWhile(path -> !suppressibleKind(path.getLeaf().getKind()))
                 .findFirst()
                 .orElseThrow(() -> {
-                    return new RuntimeException(
-                            """
-                            Can't find any source element on the TreePath to the error to \
-                            place a @SuppressWarnings on. This is a bug with suppressible-error-prone.
-                            The path to the error is:
-
-
-                            """
-                                    + StreamSupport.stream(pathToActualError.spliterator(), false)
-                                            .map(tree ->
-                                                    tree.getKind().name() + "\n===========================\n" + tree)
-                                            .collect(Collectors.joining("\n\n")));
+                    return new RuntimeException("Can't find any source element on the TreePath to the error to place a "
+                            + "@SuppressWarnings on. This is a bug with suppressible-error-prone.\n"
+                            + "The path to the error is:\n"
+                            + "\n"
+                            + "\n"
+                            + StreamSupport.stream(pathToActualError.spliterator(), false)
+                                    .map(tree -> tree.getKind().name() + "\n===========================\n" + tree)
+                                    .collect(Collectors.joining("\n\n")));
                 })
                 .getLeaf();
 
@@ -110,10 +106,13 @@ public final class VisitorStateModifications {
         }
 
         // VARIABLE includes fields
-        return switch (kind) {
-            case METHOD, VARIABLE -> true;
-            default -> false;
-        };
+        switch (kind) {
+            case METHOD:
+            case VARIABLE:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private VisitorStateModifications() {}

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesceTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesceTest.java
@@ -21,14 +21,7 @@ import org.junit.jupiter.api.Test;
 class SuppressWarningsCoalesceTest {
     @Test
     void no_suppress_warnings_no_repeatable() {
-        fix().addInput(
-                        "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            void f() {}
-                        }
-                        """)
+        fix().addInput("Test.java", String.join("\n", "public class Test {", "    void f() {}", "}"))
                 .expectUnchanged()
                 .doTest();
     }
@@ -37,13 +30,12 @@ class SuppressWarningsCoalesceTest {
     void single_suppress_warnings_no_repeatable() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings("Something")
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings(\"Something\")",
+                                "    void f() {}",
+                                "}"))
                 .expectUnchanged()
                 .doTest();
     }
@@ -52,23 +44,21 @@ class SuppressWarningsCoalesceTest {
     void multiple_suppress_warnings_single_repeatable() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings({"A", "B"})
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("C")
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings({\"A\", \"B\"})",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"C\")",
+                                "    void f() {}",
+                                "}"))
                 .addOutput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings({"A", "B", "C"})
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings({\"A\", \"B\", \"C\"})",
+                                "    void f() {}",
+                                "}"))
                 .doTest();
     }
 
@@ -76,24 +66,22 @@ class SuppressWarningsCoalesceTest {
     void single_suppress_warnings_multiple_repeatable_warnings() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("B")
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("C")
-                            @SuppressWarnings("A")
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"B\")",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"C\")",
+                                "    @SuppressWarnings(\"A\")",
+                                "    void f() {}",
+                                "}"))
                 .addOutput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings({"A", "B", "C"})
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings({\"A\", \"B\", \"C\"})",
+                                "    void f() {}",
+                                "}"))
                 .doTest();
     }
 
@@ -101,22 +89,16 @@ class SuppressWarningsCoalesceTest {
     void no_suppressible_warnings_single_repeatable_warnings() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("A")
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"A\")",
+                                "    void f() {}",
+                                "}"))
                 .addOutput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings("A")
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n", "public class Test {", "    @SuppressWarnings(\"A\")", "    void f() {}", "}"))
                 .doTest();
     }
 
@@ -124,24 +106,22 @@ class SuppressWarningsCoalesceTest {
     void multiple_suppress_warnings_multiple_repeatable_warnings() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("C")
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("D")
-                            @SuppressWarnings({"A", "B"})
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"C\")",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"D\")",
+                                "    @SuppressWarnings({\"A\", \"B\"})",
+                                "    void f() {}",
+                                "}"))
                 .addOutput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings({"A", "B", "C", "D"})
-                            void f() {}
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings({\"A\", \"B\", \"C\", \"D\"})",
+                                "    void f() {}",
+                                "}"))
                 .doTest();
     }
 
@@ -149,24 +129,22 @@ class SuppressWarningsCoalesceTest {
     void field() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("C")
-                            @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("D")
-                            @SuppressWarnings({"A", "B"})
-                            String field;
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"C\")",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"D\")",
+                                "    @SuppressWarnings({\"A\", \"B\"})",
+                                "    String field;",
+                                "}"))
                 .addOutput(
                         "Test.java",
-                        // language=Java
-                        """
-                        public class Test {
-                            @SuppressWarnings({"A", "B", "C", "D"})
-                            String field;
-                        }
-                        """)
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings({\"A\", \"B\", \"C\", \"D\"})",
+                                "    String field;",
+                                "}"))
                 .doTest();
     }
 
@@ -174,20 +152,15 @@ class SuppressWarningsCoalesceTest {
     void klass() {
         fix().addInput(
                         "Test.java",
-                        // language=Java
-                        """
-                        @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("C")
-                        @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings("D")
-                        @SuppressWarnings({"A", "B"})
-                        public class Test {}
-                        """)
+                        String.join(
+                                "\n",
+                                "@com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"C\")",
+                                "@com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"D\")",
+                                "@SuppressWarnings({\"A\", \"B\"})",
+                                "public class Test {}"))
                 .addOutput(
                         "Test.java",
-                        // language=Java
-                        """
-                        @SuppressWarnings({"A", "B", "C", "D"})
-                        public class Test {}
-                        """)
+                        String.join("\n", "@SuppressWarnings({\"A\", \"B\", \"C\", \"D\"})", "public class Test {}"))
                 .doTest();
     }
 

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -30,12 +30,12 @@ class WhitespaceIndentBeforeTest {
 
     @Test
     void start_of_string() {
-        assertThat(whitespaceIndentBefore("|class Foo {")).isEqualTo("    ");
+        assertThat(whitespaceIndentBefore("    |class Foo {")).isEqualTo("    ");
     }
 
     @Test
     void newline() {
-        assertThat(whitespaceIndentBefore("|public static void main() {")).isEqualTo("  ");
+        assertThat(whitespaceIndentBefore("\n  |public static void main() {")).isEqualTo("  ");
     }
 
     @Test

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -25,35 +25,22 @@ class WhitespaceIndentBeforeTest {
 
     @Test
     void empty_string() {
-        assertThat(whitespaceIndentBefore("""
-        |
-        """)).isEmpty();
+        assertThat(whitespaceIndentBefore("|")).isEmpty();
     }
 
     @Test
     void start_of_string() {
-        assertThat(whitespaceIndentBefore("""
-            |class Foo {
-        """))
-                .isEqualTo("    ");
+        assertThat(whitespaceIndentBefore("|class Foo {")).isEqualTo("    ");
     }
 
     @Test
     void newline() {
-        assertThat(whitespaceIndentBefore("""
-
-
-          |public static void main() {
-        """))
-                .isEqualTo("  ");
+        assertThat(whitespaceIndentBefore("|public static void main() {")).isEqualTo("  ");
     }
 
     @Test
     void something_else_is_before_on_the_same_line() {
-        assertThat(whitespaceIndentBefore("""
-        class Foo {} |class Bar {}
-        """))
-                .isEqualTo(" ");
+        assertThat(whitespaceIndentBefore("class Foo {} |class Bar {}")).isEqualTo(" ");
     }
 
     private CharSequence whitespaceIndentBefore(String testCase) {


### PR DESCRIPTION
## Before this PR
Unfortunately, there's a reasonable number of projects that still use 11 for compilation. The rollout of gradle-baseline 6.2.0 was blocked by having this code that runs inside compilation at target level 17.

## After this PR
==COMMIT_MSG==
Libraries from this repo that are used in compilation (`suppressible-error-prone`, `suppressible-error-prone-annotations`) are now targeted at JDK 11 rather than 17.
==COMMIT_MSG==

## Possible downsides?
* Custom overrides that will need to be removed at some point.
* Can't use nice source features like text blocks.

