### PR TITLE
Ensure multiple errors from the same method do not repeat in `@SuppressWarnings`

### DIFF
--- a/changelog/@unreleased/pr-24.v2.yml
+++ b/changelog/@unreleased/pr-24.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ensure multiple errors from the same method do not repeat in `@SuppressWarnings`
+    when suppressing
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/24

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesce.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesce.java
@@ -93,6 +93,7 @@ public final class SuppressWarningsCoalesce extends BugChecker
         List<String> warningsToSuppress = suppressWarnings.stream()
                 .sorted(suppressWarningsBeforeRepeatableSuppressedWarnings())
                 .flatMap(SuppressWarningsCoalesce::annotationStringValues)
+                .distinct()
                 .collect(Collectors.toList());
 
         if (warningsToSuppress.isEmpty()) {

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesceTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/SuppressWarningsCoalesceTest.java
@@ -126,6 +126,31 @@ class SuppressWarningsCoalesceTest {
     }
 
     @Test
+    void same_warnings_multiple_times() {
+        fix().addInput(
+                        "Test.java",
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"A\")",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"A\")",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"B\")",
+                                "    @com.palantir.suppressibleerrorprone.RepeatableSuppressWarnings(\"D\")",
+                                "    @SuppressWarnings({\"A\", \"B\", \"C\"})",
+                                "    void f() {}",
+                                "}"))
+                .addOutput(
+                        "Test.java",
+                        String.join(
+                                "\n",
+                                "public class Test {",
+                                "    @SuppressWarnings({\"A\", \"B\", \"C\", \"D\"})",
+                                "    void f() {}",
+                                "}"))
+                .doTest();
+    }
+
+    @Test
     void field() {
         fix().addInput(
                         "Test.java",


### PR DESCRIPTION
## Before this PR
Running on an internal repo got this SuppressWarnings:

```java
@SuppressWarnings({"for-rollout:DangerousThrowableMessageSafeArg", "for-rollout:IllegalSafeLoggingArgument", "for-rollout:LogsafeThrowableArgument", "for-rollout:DangerousThrowableMessageSafeArg", "for-rollout:IllegalSafeLoggingArgument", "for-rollout:LogsafeThrowableArgument", "for-rollout:DangerousThrowableMessageSafeArg", "for-rollout:IllegalSafeLoggingArgument", "for-rollout:LogsafeThrowableArgument"})
```

Lots of repetition of the same suppression (one for each bad log statement in this method).

## After this PR
==COMMIT_MSG==
Ensure multiple errors from the same method do not repeat in `@SuppressWarnings` when suppressing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

