### PR TITLE
Handle errors on import statements

### DIFF
--- a/changelog/@unreleased/pr-29.v2.yml
+++ b/changelog/@unreleased/pr-29.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Do not fail to suppress with an exception if there is an error on an
+    import statement.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/29

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -670,6 +670,50 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
+    def 'makes no changes when there is an error on an import'() {
+        when: 'theres an illegal import'
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public class A {
+                public static class Inner {}
+            }
+        '''.stripIndent(true)
+
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public class B extends A {}
+        '''.stripIndent(true)
+
+        // This below hits the NonCanonicalStaticImport as it should refer to app.A.Inner, not app.B.Inner
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            import static app.B.Inner;
+            public final class App {}
+        '''.stripIndent(true)
+
+        then: 'compilation fails'
+        def stderr = runTasksWithFailure('compileAllErrorProne').standardError
+        stderr.contains('[NonCanonicalStaticImport]')
+
+        when: 'we try to suppress it'
+        println runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage1').standardError
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppressStage2')
+
+        then: 'nothing has changed as we cant put SuppressWarnings on an import'
+        def stderr2 = runTasksWithFailure('compileAllErrorProne').standardError
+        stderr2.contains('[NonCanonicalStaticImport]')
+
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            import static app.B.Inner;
+            public final class App {}
+        '''.stripIndent(true)
+    }
+
     @Override
     ExecutionResult runTasksSuccessfully(String... tasks) {
         def result = runTasks(tasks)

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -16,6 +16,7 @@
 
 package com.palantir.suppressibleerrorprone;
 
+// CHECKSTYLE:OFF
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
@@ -24,11 +25,12 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+// CHECKSTYLE:ON
 
 public final class VisitorStateModifications {
+    private static final Logger log = Logger.getLogger(VisitorStateModifications.class.getName());
 
     @SuppressWarnings("RestrictedApi")
     public static Description interceptDescription(VisitorState visitorState, Description description) {
@@ -43,21 +45,23 @@ public final class VisitorStateModifications {
         TreePath pathToActualError =
                 TreePath.getPath(visitorState.getPath().getCompilationUnit(), description.position.getTree());
 
-        Tree firstSuppressibleParent = Stream.iterate(
+        Optional<TreePath> firstSuppressible = Stream.iterate(
                         pathToActualError, treePath -> treePath.getParentPath() != null, TreePath::getParentPath)
                 .dropWhile(path -> !suppressibleKind(path.getLeaf().getKind()))
-                .findFirst()
-                .orElseThrow(() -> {
-                    return new RuntimeException("Can't find any source element on the TreePath to the error to place a "
-                            + "@SuppressWarnings on. This is a bug with suppressible-error-prone.\n"
-                            + "The path to the error is:\n"
-                            + "\n"
-                            + "\n"
-                            + StreamSupport.stream(pathToActualError.spliterator(), false)
-                                    .map(tree -> tree.getKind().name() + "\n===========================\n" + tree)
-                                    .collect(Collectors.joining("\n\n")));
-                })
-                .getLeaf();
+                .findFirst();
+
+        // If we can't find a suppressible parent, we can't add a suppression, so just give up.
+        // This happens when there's a suppression on an import or compilation unit.
+        // Imports should never be at error level as we can't suppress them. Or have an autofix that *always* works.
+        if (firstSuppressible.isEmpty()) {
+            log.warning("Couldn't find a suppressible parent for " + description.checkName + " at position "
+                    + description.position.getStartPosition() + " in "
+                    + visitorState.getPath().getCompilationUnit().getSourceFile() + "."
+                    + " SuppressibleErrorProne will not be able to add a suppression for this error.");
+            return Description.NO_MATCH;
+        }
+
+        Tree firstSuppressibleParent = firstSuppressible.get().getLeaf();
 
         // Guess the indent if we can't find it for some reason. Formatter will fix.
         CharSequence indent =


### PR DESCRIPTION
## Before this PR
Currently, if there is an error on an import, suppression will fail (because there is no way to place a `@SuppressWarnings`). People shouldn't make `ImportTreeMatcher`s that are at error level or do not have an always succeeding autofixer as they can't be suppressed.

## After this PR
==COMMIT_MSG==
Do not fail to suppress with an exception if there is an error on an import statement.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

