### PR TITLE
Fix error where suppressing could produce incorrect `App@SuppressWarnings("Check").Builder` expressions

### DIFF
--- a/changelog/@unreleased/pr-40.v2.yml
+++ b/changelog/@unreleased/pr-40.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix error where suppressing could produce incorrect `App@SuppressWarnings("Check").Builder`
+    expressions
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/40

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -451,6 +451,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         writeJavaSourceFileToSourceSets '''
             package app;
             public final class App {
+                @SuppressWarnings("UnusedVariable")
                 public static void main(String[] args) {
                     App.Builder builder = new App.Builder(new int[3].toString());
                 }
@@ -468,6 +469,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         appJavaTextEquals '''
             package app;
             public final class App {
+                @SuppressWarnings("UnusedVariable")
                 public static void main(String[] args) {
                     @SuppressWarnings("for-rollout:ArrayToString")
                     App.Builder builder = new App.Builder(new int[3].toString());

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -301,9 +301,10 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-        runTasksSuccessfully('compileAllErrorProne')
-
         appJavaTextContains('@SuppressWarnings(\"for-rollout:ArrayToString\")')
+
+
+        runTasksSuccessfully('compileAllErrorProne')
     }
 
     def 'demonstrate suppressions on different source elements'() {
@@ -338,8 +339,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-        runTasksSuccessfully('compileAllErrorProne')
-
         // language=Java
         appJavaTextEquals '''
             package app;
@@ -371,6 +370,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 }
             }
         '''.stripIndent(true)
+
+        runTasksSuccessfully('compileAllErrorProne')
     }
 
     def 'supports errorprone checks that match on a larger element than they report errors on'() {
@@ -393,8 +394,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-        runTasksSuccessfully('compileAllErrorProne')
-
         // language=Java
         appJavaTextEquals '''
             package app;
@@ -405,6 +404,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 }
             }
         '''.stripIndent(true)
+
+        runTasksSuccessfully('compileAllErrorProne')
     }
 
     def 'supports suppressing errorprone checks on classes, interfaces, records, enums, etc'() {
@@ -424,8 +425,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-        runTasksSuccessfully('compileAllErrorProne')
-
         // language=Java
         appJavaTextEquals '''
             package app;
@@ -442,6 +441,45 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 @interface module {}
             }
         '''.stripIndent(true)
+
+
+        runTasksSuccessfully('compileAllErrorProne')
+    }
+
+    def 'does not place suppress warnings annotation in the middle of a Type.Builder variables reference'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    App.Builder builder = new App.Builder(new int[3].toString());
+                }
+                static class Builder {
+                    Builder(Object object) {}
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    @SuppressWarnings("for-rollout:ArrayToString")
+                    App.Builder builder = new App.Builder(new int[3].toString());
+                }
+                static class Builder {
+                    Builder(Object object) {}
+                }
+            }
+        '''.stripIndent(true)
+
+
+        runTasksSuccessfully('compileAllErrorProne')
     }
 
     def 'can disable errorprone using property'() {

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/AnnotationUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/AnnotationUtils.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.suppressibleerrorprone;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.NewArrayTree;
+import java.util.stream.Stream;
+
+final class AnnotationUtils {
+    static Stream<String> annotationStringValues(AnnotationTree annotation) {
+        return annotation.getArguments().stream().flatMap(arg -> {
+            if (!(arg instanceof AssignmentTree)) {
+                return Stream.empty();
+            }
+            AssignmentTree assignment = (AssignmentTree) arg;
+
+            ExpressionTree expression = assignment.getExpression();
+
+            if (expression instanceof LiteralTree) {
+                LiteralTree literalTree = (LiteralTree) expression;
+                return Stream.of((String) literalTree.getValue());
+            }
+
+            if (expression instanceof NewArrayTree) {
+                NewArrayTree newArray = (NewArrayTree) expression;
+                return newArray.getInitializers().stream()
+                        .map(LiteralTree.class::cast)
+                        .map(LiteralTree::getValue)
+                        .map(String.class::cast);
+            }
+
+            throw new UnsupportedOperationException("Unsupported assignment expression: "
+                    + expression.getClass().getCanonicalName());
+        });
+    }
+
+    private AnnotationUtils() {}
+}

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/FirstTimeMemoizingFunction.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/FirstTimeMemoizingFunction.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.suppressibleerrorprone;
+
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+final class FirstTimeMemoizingFunction<T, R> implements Function<T, R> {
+    private final Function<T, R> function;
+    private Optional<R> cachedValue = Optional.empty();
+
+    FirstTimeMemoizingFunction(Function<T, R> function) {
+        this.function = function;
+    }
+
+    @Override
+    public R apply(T input) {
+        return cachedValue.orElseGet(() -> {
+            R result = function.apply(input);
+            cachedValue = Optional.of(result);
+            return result;
+        });
+    }
+}

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/FirstTimeMemoizingFunction.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/FirstTimeMemoizingFunction.java
@@ -20,6 +20,11 @@ import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.concurrent.NotThreadSafe;
 
+/**
+ * Memoizes the first evaluation of a function with one parameter. Subsequent evaluations will return the value
+ * calculated in the first run, even if the argument used in subsequent evaluations differs from the argument used
+ * in the first evaluation.
+ */
 @NotThreadSafe
 final class FirstTimeMemoizingFunction<T, R> implements Function<T, R> {
     private final Function<T, R> function;

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.suppressibleerrorprone;
+
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+import java.util.Optional;
+
+final class SourceCodeUtils {
+    static CharSequence indentForTree(Optional<CharSequence> sourceCode, Tree tree) {
+        return sourceCode
+                .map(actualSourceCode ->
+                        whitespaceIndentBefore(actualSourceCode, ((DiagnosticPosition) tree).getStartPosition()))
+                .orElse("    ");
+    }
+
+    static CharSequence whitespaceIndentBefore(CharSequence sourceCode, int sourceElementPosition) {
+        int pos = sourceElementPosition - 1;
+
+        for (; pos >= 0; pos--) {
+            char character = sourceCode.charAt(pos);
+            if (character == '\n' || !Character.isWhitespace(character)) {
+                break;
+            }
+        }
+
+        return sourceCode.subSequence(pos + 1, sourceElementPosition);
+    }
+
+    private SourceCodeUtils() {}
+}

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
@@ -34,6 +34,12 @@ final class SuppressingFix implements Fix {
     private final Function<EndPosTable, ImmutableSet<Replacement>> replacement;
 
     SuppressingFix(Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
+        // See note in SuppressingReplacement about when we have to calculate stuff
+        // In order for SuppressingReplacement to calculate source code positions elements when it's constructed, it
+        // needs an EndPosTable. However, we don't get the EndPosTable until getReplacements is called. So we have
+        // to use this FirstTimeMemoizingFunction thing, that will allow use to defer creating the Replacement until
+        // we have access to the EndPosTable, then keep hold of the created SuppressingReplacement. We only need a
+        // single instance of EndPosTable to evaluate the source positions exactly once, so this works out.
         this.replacement = new FirstTimeMemoizingFunction<>((EndPosTable endPositions) -> ImmutableSet.of(
                 new SuppressingReplacement(endPositions, newSuppressions, sourceCode, suppressWarnings, tree)));
     }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
@@ -17,133 +17,34 @@
 package com.palantir.suppressibleerrorprone;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Range;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.Replacement;
 import com.google.errorprone.fixes.Replacements.CoalescePolicy;
 import com.sun.source.tree.AnnotationTree;
-import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.LiteralTree;
-import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
-import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.function.Function;
 
 final class SuppressingFix implements Fix {
-    private final Optional<CharSequence> sourceCode;
-    private final Optional<? extends AnnotationTree> suppressWarnings;
-    private final Tree tree;
-    private final Set<String> errors = new HashSet<>();
-
-    private Optional<Range<Integer>> cachedRange = Optional.empty();
+    private final Set<String> newSuppressions = new HashSet<>();
+    private final Function<EndPosTable, ImmutableSet<Replacement>> replacement;
 
     SuppressingFix(Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
-        this.sourceCode = sourceCode;
-        this.suppressWarnings = suppressWarnings;
-        this.tree = tree;
+        this.replacement = new FirstTimeMemoizingFunction<>((EndPosTable endPositions) -> ImmutableSet.of(
+                new SuppressingReplacement(endPositions, newSuppressions, sourceCode, suppressWarnings, tree)));
     }
 
-    public void suppressError(String error) {
-        errors.add(error);
+    public void addSuppression(String suppression) {
+        newSuppressions.add(suppression);
     }
 
     @Override
     public ImmutableSet<Replacement> getReplacements(EndPosTable endPositions) {
-        if (cachedRange.isEmpty()) {
-            cachedRange = Optional.of(calculateRange(endPositions));
-        }
-
-        return ImmutableSet.of(new SuppressingReplacement(() -> cachedRange.get(), this::suppressWarningsString));
-    }
-
-    private Range<Integer> calculateRange(EndPosTable endPositions) {
-        return suppressWarnings.map(annotationTree -> {
-            // @SuppressWarnings already exists, we need to replace the whole expression with our own
-            DiagnosticPosition position = (DiagnosticPosition) annotationTree;
-            return Range.closedOpen(position.getStartPosition(), position.getEndPosition(endPositions));
-        }).orElseGet(() -> {
-            // No @SuppressWarnings, we want to prefix a new one before the start of the tree
-            int startPosition = ((DiagnosticPosition) tree).getStartPosition();
-            return Range.closedOpen(startPosition, startPosition);
-        });
-    }
-
-    private String suppressWarningsString() {
-        return suppressWarnings
-                .map(this::suppressWarningsWithExistingSuppressWarnings)
-                .orElseGet(this::suppressWarningsWithoutExistingSuppressWarnings);
-    }
-
-    private String suppressWarningsWithExistingSuppressWarnings(AnnotationTree suppressWarningsAnnotation) {
-        List<String> existingSuppressions =
-                annotationStringValues(suppressWarningsAnnotation).collect(Collectors.toList());
-
-        List<String> warningsToSuppress = SuppressWarningsUtils.modifySuppressions(existingSuppressions, errors);
-
-        return SuppressWarningsUtils.suppressWarningsString(warningsToSuppress);
-    }
-
-    private String suppressWarningsWithoutExistingSuppressWarnings() {
-        String suppressWarningsString = SuppressWarningsUtils.suppressWarningsString(
-                SuppressWarningsUtils.modifySuppressions(List.of(), errors));
-
-        return suppressWarningsString + "\n" + indentForTree();
-    }
-
-    private static Stream<String> annotationStringValues(AnnotationTree annotation) {
-        return annotation.getArguments().stream().flatMap(arg -> {
-            if (!(arg instanceof AssignmentTree)) {
-                return Stream.empty();
-            }
-            AssignmentTree assignment = (AssignmentTree) arg;
-
-            ExpressionTree expression = assignment.getExpression();
-
-            if (expression instanceof LiteralTree) {
-                LiteralTree literalTree = (LiteralTree) expression;
-                return Stream.of((String) literalTree.getValue());
-            }
-
-            if (expression instanceof NewArrayTree) {
-                NewArrayTree newArray = (NewArrayTree) expression;
-                return newArray.getInitializers().stream()
-                        .map(LiteralTree.class::cast)
-                        .map(LiteralTree::getValue)
-                        .map(String.class::cast);
-            }
-
-            throw new UnsupportedOperationException("Unsupported assignment expression: "
-                    + expression.getClass().getCanonicalName());
-        });
-    }
-
-    static CharSequence whitespaceIndentBefore(CharSequence sourceCode, int sourceElementPosition) {
-        int pos = sourceElementPosition - 1;
-
-        for (; pos >= 0; pos--) {
-            char character = sourceCode.charAt(pos);
-            if (character == '\n' || !Character.isWhitespace(character)) {
-                break;
-            }
-        }
-
-        return sourceCode.subSequence(pos + 1, sourceElementPosition);
-    }
-
-    private CharSequence indentForTree() {
-        return sourceCode
-                .map(actualSourceCode ->
-                        whitespaceIndentBefore(actualSourceCode, ((DiagnosticPosition) tree).getStartPosition()))
-                .orElse("    ");
+        return replacement.apply(endPositions);
     }
 
     @Override
@@ -174,32 +75,5 @@ final class SuppressingFix implements Fix {
     @Override
     public boolean isEmpty() {
         return false;
-    }
-
-    private static final class SuppressingReplacement extends Replacement {
-        // We really do need to be this lazy for generating the Replacements, as error-prone immediately converts
-        // the Fix to a Replacement when a Description is given to it, and we need to defer the computation of the
-        // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
-        // at the same level.
-        // We *cannot* make this a memoized supplier. The first thing error-prone does with the Fix is to evaluate it
-        // to produce a nice error message, and we don't want to fix the number of suppression we make until we're
-        // ready to produce the Replacement after *all* the error-prone checks have been run.
-        private final Supplier<Range<Integer>> range;
-        private final Supplier<String> replaceWith;
-
-        public SuppressingReplacement(Supplier<Range<Integer>> range, Supplier<String> replaceWith) {
-            this.range = range;
-            this.replaceWith = replaceWith;
-        }
-
-        @Override
-        public Range<Integer> range() {
-            return range.get();
-        }
-
-        @Override
-        public String replaceWith() {
-            return replaceWith.get();
-        }
     }
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
@@ -35,6 +35,9 @@ final class SuppressingFix implements Fix {
 
     SuppressingFix(Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
         // See note in SuppressingReplacement about when we have to calculate stuff
+        // We *cannot* simply make this a memoized supplier. The first thing error-prone does with the Fix is to
+        // evaluate it to produce a nice error message, and we don't want to fix the number of suppression we make
+        // until we're ready to produce the Replacement after *all* the error-prone checks have been run.
         // In order for SuppressingReplacement to calculate source code positions elements when it's constructed, it
         // needs an EndPosTable. However, we don't get the EndPosTable until getReplacements is called. So we have
         // to use this FirstTimeMemoizingFunction thing, that will allow use to defer creating the Replacement until

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingFix.java
@@ -17,12 +17,10 @@
 package com.palantir.suppressibleerrorprone;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.Replacement;
 import com.google.errorprone.fixes.Replacements.CoalescePolicy;
-import com.google.errorprone.fixes.SuggestedFix;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ExpressionTree;
@@ -46,6 +44,8 @@ final class SuppressingFix implements Fix {
     private final Tree tree;
     private final Set<String> errors = new HashSet<>();
 
+    private Optional<Range<Integer>> cachedRange = Optional.empty();
+
     SuppressingFix(Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
         this.sourceCode = sourceCode;
         this.suppressWarnings = suppressWarnings;
@@ -58,32 +58,45 @@ final class SuppressingFix implements Fix {
 
     @Override
     public ImmutableSet<Replacement> getReplacements(EndPosTable endPositions) {
-        return ImmutableSet.of(
-                new SuppressingReplacement(() -> Iterables.getOnlyElement(fix().getReplacements(endPositions))));
+        if (cachedRange.isEmpty()) {
+            cachedRange = Optional.of(calculateRange(endPositions));
+        }
+
+        return ImmutableSet.of(new SuppressingReplacement(() -> cachedRange.get(), this::suppressWarningsString));
     }
 
-    private Fix fix() {
+    private Range<Integer> calculateRange(EndPosTable endPositions) {
+        return suppressWarnings.map(annotationTree -> {
+            // @SuppressWarnings already exists, we need to replace the whole expression with our own
+            DiagnosticPosition position = (DiagnosticPosition) annotationTree;
+            return Range.closedOpen(position.getStartPosition(), position.getEndPosition(endPositions));
+        }).orElseGet(() -> {
+            // No @SuppressWarnings, we want to prefix a new one before the start of the tree
+            int startPosition = ((DiagnosticPosition) tree).getStartPosition();
+            return Range.closedOpen(startPosition, startPosition);
+        });
+    }
+
+    private String suppressWarningsString() {
         return suppressWarnings
-                .map(this::fixWithExistingSuppressWarnings)
-                .orElseGet(this::fixWithoutExistingSuppressWarnings);
+                .map(this::suppressWarningsWithExistingSuppressWarnings)
+                .orElseGet(this::suppressWarningsWithoutExistingSuppressWarnings);
     }
 
-    private SuggestedFix fixWithExistingSuppressWarnings(AnnotationTree suppressWarningsAnnotation) {
+    private String suppressWarningsWithExistingSuppressWarnings(AnnotationTree suppressWarningsAnnotation) {
         List<String> existingSuppressions =
                 annotationStringValues(suppressWarningsAnnotation).collect(Collectors.toList());
 
         List<String> warningsToSuppress = SuppressWarningsUtils.modifySuppressions(existingSuppressions, errors);
 
-        String suppressWarningsString = SuppressWarningsUtils.suppressWarningsString(warningsToSuppress);
-
-        return SuggestedFix.replace(suppressWarningsAnnotation, suppressWarningsString);
+        return SuppressWarningsUtils.suppressWarningsString(warningsToSuppress);
     }
 
-    private SuggestedFix fixWithoutExistingSuppressWarnings() {
+    private String suppressWarningsWithoutExistingSuppressWarnings() {
         String suppressWarningsString = SuppressWarningsUtils.suppressWarningsString(
                 SuppressWarningsUtils.modifySuppressions(List.of(), errors));
 
-        return SuggestedFix.prefixWith(tree, suppressWarningsString + "\n" + indentForTree());
+        return suppressWarningsString + "\n" + indentForTree();
     }
 
     private static Stream<String> annotationStringValues(AnnotationTree annotation) {
@@ -171,20 +184,22 @@ final class SuppressingFix implements Fix {
         // We *cannot* make this a memoized supplier. The first thing error-prone does with the Fix is to evaluate it
         // to produce a nice error message, and we don't want to fix the number of suppression we make until we're
         // ready to produce the Replacement after *all* the error-prone checks have been run.
-        private final Supplier<Replacement> replacement;
+        private final Supplier<Range<Integer>> range;
+        private final Supplier<String> replaceWith;
 
-        SuppressingReplacement(Supplier<Replacement> replacement) {
-            this.replacement = replacement;
+        public SuppressingReplacement(Supplier<Range<Integer>> range, Supplier<String> replaceWith) {
+            this.range = range;
+            this.replaceWith = replaceWith;
         }
 
         @Override
         public Range<Integer> range() {
-            return replacement.get().range();
+            return range.get();
         }
 
         @Override
         public String replaceWith() {
-            return replacement.get().replaceWith();
+            return replaceWith.get();
         }
     }
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
@@ -33,9 +33,18 @@ final class SuppressingReplacement extends Replacement {
     // the Fix to a Replacement when a Description is given to it, and we need to defer the computation of the
     // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
     // at the same level.
-    // We *cannot* make this a memoized supplier. The first thing error-prone does with the Fix is to evaluate it
+    //
+    // We *cannot* simply make this a memoized supplier. The first thing error-prone does with the Fix is to evaluate it
     // to produce a nice error message, and we don't want to fix the number of suppression we make until we're
     // ready to produce the Replacement after *all* the error-prone checks have been run.
+    //
+    // There is an additional issue that by the time error-prone comes around to apply the replacements, the compiler
+    // seems to change the representation of the tree for another phase - `App.Builder` becomes `App$Builder` etc and
+    // all the source code positions change. If we calculate the replacement range too late, we insert our
+    // @SuppressWarnings at the wrong location, and the indentation is miscalculated. But we can't calculate the
+    // replacement string straight away, as we might not have all the new suppressions added yet. So we have to
+    // immediately calculate the replacement range and indentation, but hold off building the final replacement
+    // string until we have all the new suppressions.
 
     private final Range<Integer> range;
     private final List<String> existingSuppressions;
@@ -57,7 +66,9 @@ final class SuppressingReplacement extends Replacement {
                 .collect(Collectors.toList());
 
         this.suffix = suppressWarnings
+                // If we're replacing an existing @SuppressWarnings, there's no need to add an indent
                 .map(_ignored -> "")
+                // If we're adding a new @SuppressWarnings, we need to indent the next line correctly
                 .orElseGet(() -> "\n" + SourceCodeUtils.indentForTree(sourceCode, tree));
     }
 

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
@@ -1,0 +1,137 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.suppressibleerrorprone;
+
+import com.google.common.collect.Range;
+import com.google.errorprone.fixes.Replacement;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.tree.EndPosTable;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class SuppressingReplacement extends Replacement {
+    // We really do need to be this lazy for generating the Replacements, as error-prone immediately converts
+    // the Fix to a Replacement when a Description is given to it, and we need to defer the computation of the
+    // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
+    // at the same level.
+    // We *cannot* make this a memoized supplier. The first thing error-prone does with the Fix is to evaluate it
+    // to produce a nice error message, and we don't want to fix the number of suppression we make until we're
+    // ready to produce the Replacement after *all* the error-prone checks have been run.
+
+    private final Range<Integer> range;
+    private final List<String> existingSuppressions;
+    private final String suffix;
+    private final Set<String> newSuppressions;
+
+    SuppressingReplacement(
+            EndPosTable endPositions,
+            Set<String> newSuppressions,
+            Optional<CharSequence> sourceCode,
+            Optional<? extends AnnotationTree> suppressWarnings,
+            Tree tree) {
+        this.newSuppressions = newSuppressions;
+        this.range = calculateRange(endPositions, suppressWarnings, tree);
+        this.existingSuppressions = suppressWarnings
+                .map(SuppressingReplacement::annotationStringValues)
+                .orElseGet(Stream::of)
+                .collect(Collectors.toList());
+        this.suffix = suppressWarnings.map(_ignored -> "").orElseGet(() -> "\n" + indentForTree(sourceCode, tree));
+    }
+
+    @Override
+    public Range<Integer> range() {
+        return range;
+    }
+
+    @Override
+    public String replaceWith() {
+        return SuppressWarningsUtils.suppressWarningsString(
+                        SuppressWarningsUtils.modifySuppressions(existingSuppressions, newSuppressions))
+                + suffix;
+    }
+
+    private static Range<Integer> calculateRange(
+            EndPosTable endPositions, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
+        return suppressWarnings
+                .map(annotationTree -> {
+                    // @SuppressWarnings already exists, we need to replace the whole expression with our own
+                    DiagnosticPosition position = (DiagnosticPosition) annotationTree;
+                    return Range.closedOpen(position.getStartPosition(), position.getEndPosition(endPositions));
+                })
+                .orElseGet(() -> {
+                    // No @SuppressWarnings, we want to prefix a new one before the start of the tree
+                    int startPosition = ((DiagnosticPosition) tree).getStartPosition();
+                    return Range.closedOpen(startPosition, startPosition);
+                });
+    }
+
+    private static CharSequence indentForTree(Optional<CharSequence> sourceCode, Tree tree) {
+        return sourceCode
+                .map(actualSourceCode ->
+                        whitespaceIndentBefore(actualSourceCode, ((DiagnosticPosition) tree).getStartPosition()))
+                .orElse("    ");
+    }
+
+    private static Stream<String> annotationStringValues(AnnotationTree annotation) {
+        return annotation.getArguments().stream().flatMap(arg -> {
+            if (!(arg instanceof AssignmentTree)) {
+                return Stream.empty();
+            }
+            AssignmentTree assignment = (AssignmentTree) arg;
+
+            ExpressionTree expression = assignment.getExpression();
+
+            if (expression instanceof LiteralTree) {
+                LiteralTree literalTree = (LiteralTree) expression;
+                return Stream.of((String) literalTree.getValue());
+            }
+
+            if (expression instanceof NewArrayTree) {
+                NewArrayTree newArray = (NewArrayTree) expression;
+                return newArray.getInitializers().stream()
+                        .map(LiteralTree.class::cast)
+                        .map(LiteralTree::getValue)
+                        .map(String.class::cast);
+            }
+
+            throw new UnsupportedOperationException("Unsupported assignment expression: "
+                    + expression.getClass().getCanonicalName());
+        });
+    }
+
+    private static CharSequence whitespaceIndentBefore(CharSequence sourceCode, int sourceElementPosition) {
+        int pos = sourceElementPosition - 1;
+
+        for (; pos >= 0; pos--) {
+            char character = sourceCode.charAt(pos);
+            if (character == '\n' || !Character.isWhitespace(character)) {
+                break;
+            }
+        }
+
+        return sourceCode.subSequence(pos + 1, sourceElementPosition);
+    }
+}

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
@@ -34,10 +34,6 @@ final class SuppressingReplacement extends Replacement {
     // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
     // at the same level.
     //
-    // We *cannot* simply make this a memoized supplier. The first thing error-prone does with the Fix is to evaluate it
-    // to produce a nice error message, and we don't want to fix the number of suppression we make until we're
-    // ready to produce the Replacement after *all* the error-prone checks have been run.
-    //
     // There is an additional issue that by the time error-prone comes around to apply the replacements, the compiler
     // seems to change the representation of the tree for another phase - `App.Builder` becomes `App$Builder` etc and
     // the start position for the expression changes to be after `App` rather than at the start of `App`.

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
@@ -26,21 +26,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 final class SuppressingReplacement extends Replacement {
     // We really do need to be this lazy for generating the Replacements, as error-prone immediately converts
     // the Fix to a Replacement when a Description is given to it, and we need to defer the computation of the
     // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
     // at the same level.
-    //
-    // There is an additional issue that by the time error-prone comes around to apply the replacements, the compiler
-    // seems to change the representation of the tree for another phase - `App.Builder` becomes `App$Builder` etc and
-    // the start position for the expression changes to be after `App` rather than at the start of `App`.
-    // If we calculate the replacement range too late, we insert our @SuppressWarnings at the wrong location, and
-    // the indentation is miscalculated. But we can't calculate the replacement string straight away, as we might not
-    // have all the new suppressions added yet. So we have to immediately calculate the replacement range and
-    // indentation, but hold off building the final replacement string until we have all the new suppressions.
 
     private final Range<Integer> range;
     private final List<String> existingSuppressions;
@@ -53,19 +44,29 @@ final class SuppressingReplacement extends Replacement {
             Optional<CharSequence> sourceCode,
             Optional<? extends AnnotationTree> suppressWarnings,
             Tree tree) {
+        // Note this is a *mutable* set from SuppressingFix, we need to able to add a new suppression before this
+        // instance is instantiated
         this.newSuppressions = newSuppressions;
-        this.range = calculateRange(endPositions, suppressWarnings, tree);
 
-        this.existingSuppressions = suppressWarnings
-                .map(AnnotationUtils::annotationStringValues)
-                .orElseGet(Stream::of)
-                .collect(Collectors.toList());
+        // There is an additional issue that by the time error-prone comes around to apply the replacements, the
+        // compiler seems to change the representation of the tree for another phase - `App.Builder` becomes
+        // `App$Builder` etc and the start position for the expression changes to be after `App` rather than at the
+        // start of `App`. If we calculate the replacement range too late, we insert our @SuppressWarnings at the
+        // wrong location, and the indentation is miscalculated. But we can't calculate the replacement string
+        // straight away, as we might not have all the new suppressions added yet. So we have to immediately
+        // calculate the replacement range and indentation/suffix, but hold off building the final replacement
+        // string until we have all the new suppressions.
+        this.range = calculateRange(endPositions, suppressWarnings, tree);
 
         this.suffix = suppressWarnings
                 // If we're replacing an existing @SuppressWarnings, there's no need to add an indent
                 .map(_ignored -> "")
                 // If we're adding a new @SuppressWarnings, we need to indent the next line correctly
                 .orElseGet(() -> "\n" + SourceCodeUtils.indentForTree(sourceCode, tree));
+
+        this.existingSuppressions = suppressWarnings.stream()
+                .flatMap(AnnotationUtils::annotationStringValues)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
@@ -19,10 +19,6 @@ package com.palantir.suppressibleerrorprone;
 import com.google.common.collect.Range;
 import com.google.errorprone.fixes.Replacement;
 import com.sun.source.tree.AnnotationTree;
-import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.LiteralTree;
-import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -54,11 +50,15 @@ final class SuppressingReplacement extends Replacement {
             Tree tree) {
         this.newSuppressions = newSuppressions;
         this.range = calculateRange(endPositions, suppressWarnings, tree);
+
         this.existingSuppressions = suppressWarnings
-                .map(SuppressingReplacement::annotationStringValues)
+                .map(AnnotationUtils::annotationStringValues)
                 .orElseGet(Stream::of)
                 .collect(Collectors.toList());
-        this.suffix = suppressWarnings.map(_ignored -> "").orElseGet(() -> "\n" + indentForTree(sourceCode, tree));
+
+        this.suffix = suppressWarnings
+                .map(_ignored -> "")
+                .orElseGet(() -> "\n" + SourceCodeUtils.indentForTree(sourceCode, tree));
     }
 
     @Override
@@ -86,52 +86,5 @@ final class SuppressingReplacement extends Replacement {
                     int startPosition = ((DiagnosticPosition) tree).getStartPosition();
                     return Range.closedOpen(startPosition, startPosition);
                 });
-    }
-
-    private static CharSequence indentForTree(Optional<CharSequence> sourceCode, Tree tree) {
-        return sourceCode
-                .map(actualSourceCode ->
-                        whitespaceIndentBefore(actualSourceCode, ((DiagnosticPosition) tree).getStartPosition()))
-                .orElse("    ");
-    }
-
-    private static Stream<String> annotationStringValues(AnnotationTree annotation) {
-        return annotation.getArguments().stream().flatMap(arg -> {
-            if (!(arg instanceof AssignmentTree)) {
-                return Stream.empty();
-            }
-            AssignmentTree assignment = (AssignmentTree) arg;
-
-            ExpressionTree expression = assignment.getExpression();
-
-            if (expression instanceof LiteralTree) {
-                LiteralTree literalTree = (LiteralTree) expression;
-                return Stream.of((String) literalTree.getValue());
-            }
-
-            if (expression instanceof NewArrayTree) {
-                NewArrayTree newArray = (NewArrayTree) expression;
-                return newArray.getInitializers().stream()
-                        .map(LiteralTree.class::cast)
-                        .map(LiteralTree::getValue)
-                        .map(String.class::cast);
-            }
-
-            throw new UnsupportedOperationException("Unsupported assignment expression: "
-                    + expression.getClass().getCanonicalName());
-        });
-    }
-
-    private static CharSequence whitespaceIndentBefore(CharSequence sourceCode, int sourceElementPosition) {
-        int pos = sourceElementPosition - 1;
-
-        for (; pos >= 0; pos--) {
-            char character = sourceCode.charAt(pos);
-            if (character == '\n' || !Character.isWhitespace(character)) {
-                break;
-            }
-        }
-
-        return sourceCode.subSequence(pos + 1, sourceElementPosition);
     }
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressingReplacement.java
@@ -40,11 +40,11 @@ final class SuppressingReplacement extends Replacement {
     //
     // There is an additional issue that by the time error-prone comes around to apply the replacements, the compiler
     // seems to change the representation of the tree for another phase - `App.Builder` becomes `App$Builder` etc and
-    // all the source code positions change. If we calculate the replacement range too late, we insert our
-    // @SuppressWarnings at the wrong location, and the indentation is miscalculated. But we can't calculate the
-    // replacement string straight away, as we might not have all the new suppressions added yet. So we have to
-    // immediately calculate the replacement range and indentation, but hold off building the final replacement
-    // string until we have all the new suppressions.
+    // the start position for the expression changes to be after `App` rather than at the start of `App`.
+    // If we calculate the replacement range too late, we insert our @SuppressWarnings at the wrong location, and
+    // the indentation is miscalculated. But we can't calculate the replacement string straight away, as we might not
+    // have all the new suppressions added yet. So we have to immediately calculate the replacement range and
+    // indentation, but hold off building the final replacement string until we have all the new suppressions.
 
     private final Range<Integer> range;
     private final List<String> existingSuppressions;

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -98,7 +98,7 @@ public final class VisitorStateModifications {
                 _ignored -> new SuppressingFix(
                         Optional.ofNullable(visitorState.getSourceCode()), suppressWarnings, firstSuppressibleParent));
 
-        suppressingFix.suppressError(description.checkName);
+        suppressingFix.addSuppression(description.checkName);
 
         // If we already submitted our mutable fix, we don't need to do so again, just need to add the error to the fix.
         if (alreadyReportedFix) {

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -44,6 +44,6 @@ class WhitespaceIndentBeforeTest {
     }
 
     private CharSequence whitespaceIndentBefore(String testCase) {
-        return SuppressingReplacement.whitespaceIndentBefore(testCase.replace("|", ""), testCase.indexOf('|'));
+        return SourceCodeUtils.whitespaceIndentBefore(testCase.replace("|", ""), testCase.indexOf('|'));
     }
 }

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -44,6 +44,6 @@ class WhitespaceIndentBeforeTest {
     }
 
     private CharSequence whitespaceIndentBefore(String testCase) {
-        return SuppressingFix.whitespaceIndentBefore(testCase.replace("|", ""), testCase.indexOf('|'));
+        return SuppressingReplacement.whitespaceIndentBefore(testCase.replace("|", ""), testCase.indexOf('|'));
     }
 }


### PR DESCRIPTION
## Before this PR
We were producing expressions of the form:

```java
App@SuppressWarnings("Check").Builder variable = <expression-with-error>;
```

instead of the correct:

```java
@SuppressWarnings("Check")
App.Builder variable = <expression-with-error>;
```

This is because of the new approach in #39, we hold onto source elements for much longer, and evaluate source code positions of tree elements in later compiler passes. The start positions of these tree elements have then changed, resulting in the bug above. There are detailed comments in the diff.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix error where suppressing could produce incorrect `App@SuppressWarnings("Check").Builder` expressions
==COMMIT_MSG==

We fix the problem by evaluating this information as soon as we can, rather than deferring until error-prone actually does the replacement applications.

## Possible downsides?
The fact that we have to evaluate different bits of information for the replacement at different stages (replacement range earlier, replacement string later), as well as getting the `EndPosTable` at a different to do this, makes this more complicated. Now there is code that is more comments than code to explain it :)

