### PR TITLE
Allow running `-PerrorProneApply` and `-PerrorProneSuppress` at the same time

### DIFF
--- a/changelog/@unreleased/pr-43.v2.yml
+++ b/changelog/@unreleased/pr-43.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Running `-PerrorProneApply` and `-PerrorProneSuppress` at the same
+    time is now possible, saving compilation time.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/43

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -37,7 +37,7 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.process.CommandLineArgumentProvider;
 
 public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
-    private static final String SUPPRESS_STAGE = "errorProneSuppress";
+    private static final String ERROR_PRONE_SUPPRESS = "errorProneSuppress";
     private static final String ERROR_PRONE_APPLY = "errorProneApply";
     private static final String ERROR_PRONE_DISABLE = "errorProneDisable";
     private static final String ERROR_PRONE_TIMINGS = "errorProneTimings";
@@ -291,7 +291,7 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
     }
 
     private static boolean isSuppressing(Project project) {
-        return project.hasProperty(SuppressibleErrorPronePlugin.SUPPRESS_STAGE);
+        return project.hasProperty(SuppressibleErrorPronePlugin.ERROR_PRONE_SUPPRESS);
     }
 
     static String excludedPathsRegex() {

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -205,10 +205,30 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
             errorProneOptions.getErrorproneArgumentProviders().add(new CommandLineArgumentProvider() {
                 @Override
                 public Iterable<String> asArguments() {
-                    // "-XepPatchChecks:" patches *all* the checks that are enabled
+                    // "-XepPatchChecks:" patches *all* the checks that are enabled, allowing us to suppress any check
                     return List.of("-XepPatchLocation:IN_PLACE", "-XepPatchChecks:");
                 }
             });
+
+            if (isApplyingSuggestedPatches(project)) {
+                // If we're applying suggested patches at the same time as suppressing, we still need to tell
+                // errorprone to patch all checks, so we can make suggested fixes for suppressions in any check.
+                // However, inside our changes to errorprone, we need to get the list of checks that we're going
+                // to use the default suggested fixes for, so we can work out which ones to use the suggested
+                // fixes for and which to suppress. So we add the PreferPatchChecks argument here, which we can
+                // use inside error-prone/the compiler.
+                errorProneOptions.getErrorproneArgumentProviders().add(new CommandLineArgumentProvider() {
+                    @Override
+                    public Iterable<String> asArguments() {
+                        List<String> patchChecks =
+                                checksToApplySuggestedPatchesFor(extension, javaCompile, errorProneOptions);
+
+                        return List.of(
+                                "-XepOpt:SuppressibleErrorProne:PreferPatchChecks=" + String.join(",", patchChecks));
+                    }
+                });
+            }
+
             return;
         }
 
@@ -216,29 +236,8 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
             errorProneOptions.getErrorproneArgumentProviders().add(new CommandLineArgumentProvider() {
                 @Override
                 public Iterable<String> asArguments() {
-                    String possibleSpecificPatchChecks = (String) project.property(ERROR_PRONE_APPLY);
-
-                    boolean hasSpecificPatchChecks =
-                            possibleSpecificPatchChecks != null && !possibleSpecificPatchChecks.isBlank();
-
-                    if (hasSpecificPatchChecks) {
-                        List<String> specificPatchChecks = Arrays.stream(possibleSpecificPatchChecks.split(","))
-                                .map(String::trim)
-                                .filter(Predicate.not(String::isEmpty))
-                                .toList();
-
-                        return List.of(
-                                "-XepPatchLocation:IN_PLACE",
-                                "-XepPatchChecks:" + String.join(",", specificPatchChecks));
-                    }
-
-                    List<String> patchChecks = extension.patchChecksForCompilation(javaCompile).stream()
-                            // Do not patch checks that have been explicitly disabled
-                            .filter(check ->
-                                    errorProneOptions.getChecks().getting(check).getOrNull() != CheckSeverity.OFF)
-                            // Sorted so that we maintain arg ordering and continue to get cache hits
-                            .sorted()
-                            .collect(Collectors.toList());
+                    List<String> patchChecks =
+                            checksToApplySuggestedPatchesFor(extension, javaCompile, errorProneOptions);
 
                     // If there are no checks to patch, we don't patch anything and just do a regular compile.
                     // The behaviour of "-XepPatchChecks:" is to patch *all* checks that are enabled, so we can't
@@ -251,6 +250,28 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 }
             });
         }
+    }
+
+    private static List<String> checksToApplySuggestedPatchesFor(
+            SuppressibleErrorProneExtension extension, JavaCompile javaCompile, ErrorProneOptions errorProneOptions) {
+
+        String possibleSpecificPatchChecks = (String) javaCompile.getProject().property(ERROR_PRONE_APPLY);
+
+        boolean hasSpecificPatchChecks = possibleSpecificPatchChecks != null && !possibleSpecificPatchChecks.isBlank();
+
+        if (hasSpecificPatchChecks) {
+            return Arrays.stream(possibleSpecificPatchChecks.split(","))
+                    .map(String::trim)
+                    .filter(Predicate.not(String::isEmpty))
+                    .toList();
+        }
+
+        return extension.patchChecksForCompilation(javaCompile).stream()
+                // Do not patch checks that have been explicitly disabled
+                .filter(check -> errorProneOptions.getChecks().getting(check).getOrNull() != CheckSeverity.OFF)
+                // Sorted so that we maintain arg ordering and continue to get cache hits
+                .sorted()
+                .collect(Collectors.toList());
     }
 
     private static ErrorProneOptions errorProneOptionsFor(JavaCompile javaCompile) {

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -484,6 +484,46 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         runTasksSuccessfully('compileAllErrorProne')
     }
 
+    def 'can run apply and suppress at the same time - it uses the suggested fix if a patch check, suppresses otherwise'() {
+        // language=Gradle
+        buildFile << '''
+            suppressibleErrorProne {
+                patchChecks.add('ArrayToString')
+            }
+        '''.stripIndent(true)
+
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                    System.out.println(new int[3].equals(new int[3]));
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply', '-PerrorProneSuppress')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import java.util.Arrays;
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayEquals")
+                public static void main(String[] args) {
+                    System.out.println(Arrays.toString(new int[3]));
+                    System.out.println(new int[3].equals(new int[3]));
+                }
+            }
+        '''.stripIndent(true)
+
+        runTasksSuccessfully('compileAllErrorProne')
+    }
+
     def 'can disable errorprone using property'() {
         when: 'there is java code some that will fail an errorprone during compilation'
         // language=Java

--- a/readme.md
+++ b/readme.md
@@ -90,24 +90,30 @@ This plugin adds a marker task you can handily use that will run all the compile
 ./gradlew compileAllErrorProne
 ```
 
-To actually suppress all the current failures, you need to run compilation twice:
+To actually suppress all the current failure run:
 
 ```
 ./gradlew compileAllErrorProne -PerrorProneSuppress
 ```
 
-If rolling out automatically to lots of repos, we'd recommend running the fixes first before suppressing:
+To apply suggested fixes to all the checks you have opted into via `patchChecks`:
 
 ```
 ./gradlew compileAllErrorProne -PerrorProneApply
 ```
 
-You can also run fixes for individual checks:
+You can also apply suggested fixes for individual checks:
 
 ```
 ./gradlew compileAllErrorProne -PerrorProneApply=Check
 ./gradlew compileAllErrorProne -PerrorProneApply=Check,OtherCheck
 ```
+
+Both applying suggested fixes and suppressing errors can be done in one go:
+
+```
+./gradlew compileAllErrorProne -PerrorProneSuppress -PerrorProneApply
+``` 
 
 Errorprone can be disabled by using the `-PerrorProneDisable` property.
 

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -61,9 +61,10 @@ public final class VisitorStateModifications {
         Set<String> patchChecks =
                 visitorState.errorProneOptions().getFlags().getSetOrEmpty("SuppressibleErrorProne:PreferPatchChecks");
 
-        boolean shouldPreferPatching = patchChecks.contains(description.checkName);
+        boolean shouldPreferDefaultSuggestedFixesForThisCheck = patchChecks.contains(description.checkName);
+        boolean checkHasSuggestedFixes = !description.fixes.isEmpty();
 
-        if (shouldPreferPatching && !description.fixes.isEmpty()) {
+        if (shouldPreferDefaultSuggestedFixesForThisCheck && checkHasSuggestedFixes) {
             return description;
         }
 

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -31,6 +31,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -49,6 +50,20 @@ public final class VisitorStateModifications {
     @SuppressWarnings("RestrictedApi")
     public static Description interceptDescription(VisitorState visitorState, Description description) {
         if (description == Description.NO_MATCH) {
+            return description;
+        }
+
+        // If both -PerrorProneSuppress and -PerrorProneApply are used at the same time, for the checks configured as
+        // "patchChecks" in the extension we need to use their suggested fixes instead of suppressing, so we can do
+        // both in one pass as if you'd run -PerrorProneApply and -PerrorProneSuppress separately. We pass the checks
+        // we prefer patching in this flag, as we still need errorprone to allow patching every check, so we can add
+        // our suppressions.
+        Set<String> patchChecks =
+                visitorState.errorProneOptions().getFlags().getSetOrEmpty("SuppressibleErrorProne:PreferPatchChecks");
+
+        boolean shouldPreferPatching = patchChecks.contains(description.checkName);
+
+        if (shouldPreferPatching && !description.fixes.isEmpty()) {
             return description;
         }
 


### PR DESCRIPTION
## Before this PR
Currently, when rolling out errorprone changes, we first apply suggested fixes then suppress anything that was not autofixed. This requires two whole compilations:

```
./gradlew compileAllErrorProne -PerrorProneApply
./gradlew compileAllErrorProne -PerrorProneSuppress
```

This is quite wasteful, especially as some internal projects take nearly 10 mins to compile, this is can get very close to the default excavator timeout when run twice.

I also want to get nit-bot to suppress errorprone errors introduced in excavator PRs, which is quite a problem. For example, caffeine introduced a change that angers `NullAway`, and there are many failing excavators that have not worked because this was not suppressed. It would be very wasteful to run errorprone suppression on every excavator, hence nit-bot is ideal to detect when it is needed. Currently, nit-bot only allows one command (I guess I could use a shell to run two runs...) but makes sense to avoid wasting nit-bot execution time.

## After this PR
==COMMIT_MSG==
Running `-PerrorProneApply` and `-PerrorProneSuppress` at the same time is now possible, saving compilation time.
==COMMIT_MSG==

## Possible downsides?
Slightly more complexity, there is another "mode".
