### PR TITLE
Ensure that compile tasks are not up-to-date when making changes

### DIFF
--- a/changelog/@unreleased/pr-45.v2.yml
+++ b/changelog/@unreleased/pr-45.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Compilation tasks are now never up-to-date when performing `-PerrorProneApply`
+    or `-PerrorProneSuppress`, meaning they should always make changes.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/45

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -178,8 +178,9 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
         }
 
         if (isAnyKindOfPatching(project)) {
-            // Don't attempt to cache since it won't capture the source files that might be modified
+            // Don't attempt to cache or be up-to-date since it won't capture the source files that might be modified
             javaCompile.getOutputs().cacheIf(t -> false);
+            javaCompile.getOutputs().upToDateWhen(t -> false);
         }
     }
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -19,6 +19,7 @@ package com.palantir.gradle.suppressibleerrorprone
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
+import spock.lang.Unroll
 
 class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
     // We need to put the source sets in a different directory that does not contain the any words that would hit
@@ -811,6 +812,47 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         new File(projectDir, 'build/errorprone-timings/compileOtherJava').exists()
     }
 
+    @Unroll
+    def 'compile tasks are never up-to-date when applying changes under #mode'() {
+        // language=Gradle
+        buildFile << '''
+            suppressibleErrorProne {
+                patchChecks.add('ArrayToString')
+            }
+        '''.stripIndent(true)
+
+        // language=Java
+        def originalSource = '''
+            package app;
+            public final class App {
+                public static void main(String... args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        writeJavaSourceFileToSourceSets originalSource
+
+        when: 'a compilation with code changes happens'
+        runTasksSuccessfully('compileAllErrorProne', *mode)
+
+        then: 'the source code is reset back to the original state'
+        writeJavaSourceFileToSourceSets originalSource
+
+        when: 'compilation with changes runs again'
+        runTasksSuccessfully('compileAllErrorProne', *mode)
+
+        then: 'changes are actually made, it was not up-to-date'
+        appJavaTextNotEquals originalSource
+
+        where:
+        mode << [
+                ['-PerrorProneApply'],
+                ['-PerrorProneSuppress'],
+                ['-PerrorProneApply', '-PerrorProneSuppress']
+        ]
+    }
+
     @Override
     ExecutionResult runTasksSuccessfully(String... tasks) {
         def result = runTasks(tasks)
@@ -842,8 +884,13 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         assert !file('app/App.java', otherSourceSet).text.contains(substring)
     }
 
-    void appJavaTextEquals(String substring) {
-        assert file('app/App.java', mainSourceSet).text == substring
-        assert file('app/App.java', otherSourceSet).text == substring
+    void appJavaTextEquals(String source) {
+        assert file('app/App.java', mainSourceSet).text == source
+        assert file('app/App.java', otherSourceSet).text == source
+    }
+
+    void appJavaTextNotEquals(String source) {
+        assert file('app/App.java', mainSourceSet).text != source
+        assert file('app/App.java', otherSourceSet).text != source
     }
 }


### PR DESCRIPTION
## Before this PR
We have a problem internally when trying to suppress failing errorprones via a bot. The bot has a long lived checkout of the repo's source code. It appears that the compile tasks are up-to-date when trying to apply the changes. This means the changes never get made.

## After this PR
==COMMIT_MSG==
Compilation tasks are now never up-to-date when performing `-PerrorProneApply` or `-PerrorProneSuppress`, meaning they should always make changes.
==COMMIT_MSG==

In Excavator, I _think_ this was not a problem (although it may be, we just never realised), because of how we setup the buildscript dependencies the buildscript classpath was never the same so the compile tasks were never up-to-date.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

