### PR TITLE
Throw exception when `-PerrorProneDisable` is combined with `-PerrorProneApply` or `-PerrorProneSuppress`

### DIFF
--- a/changelog/@unreleased/pr-47.v2.yml
+++ b/changelog/@unreleased/pr-47.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Throw exception when `-PerrorProneDisable` is combined with `-PerrorProneApply`
+    or `-PerrorProneSuppress`
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/47

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -53,6 +53,11 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
     }
 
     private void applyToJavaProject(Project project) {
+        if (isDisabled(project) && isAnyKindOfPatching(project)) {
+            throw new IllegalStateException(
+                    "-PerrorProneDisable cannot be used at the same time as -PerrorProneApply or -PerrorProneSuppress");
+        }
+
         project.getPluginManager().apply(ErrorPronePlugin.class);
 
         SuppressibleErrorProneExtension extension =
@@ -190,11 +195,7 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {
 
-        errorProneOptions.getEnabled().set(project.provider(() -> {
-            boolean newDisable = project.hasProperty(ERROR_PRONE_DISABLE);
-            boolean oldDisable = isDisabledViaLegacyBaselineProperty(project);
-            return !(newDisable || oldDisable);
-        }));
+        errorProneOptions.getEnabled().set(project.provider(() -> !isDisabled(project)));
 
         // This doesn't seem to do what you'd expect: disabling the checks in the generated code. But it was enabled
         // when this code lived in baseline, so we'll keep it enabled.
@@ -302,6 +303,12 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
 
         // language=RegExp
         return ".*/(build|generated_.*[sS]rc|src/generated.*)/.*";
+    }
+
+    private static boolean isDisabled(Project project) {
+        boolean newDisable = project.hasProperty(ERROR_PRONE_DISABLE);
+        boolean oldDisable = isDisabledViaLegacyBaselineProperty(project);
+        return newDisable || oldDisable;
     }
 
     private static boolean isDisabledViaLegacyBaselineProperty(Project project) {

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -19,6 +19,7 @@ package com.palantir.gradle.suppressibleerrorprone
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
+import org.assertj.core.util.Throwables
 import spock.lang.Unroll
 
 class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
@@ -851,6 +852,20 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 ['-PerrorProneSuppress'],
                 ['-PerrorProneApply', '-PerrorProneSuppress']
         ]
+    }
+
+    def 'throws exception when -PerrorProneDisable is combined with -PerrorProneApply or -PerrorProneSuppress'() {
+        when:
+        def applyMessage = Throwables.getRootCause(runTasksWithFailure('compileAllErrorProne', '-PerrorProneDisable', '-PerrorProneApply').failure).message
+
+        then:
+        applyMessage.contains '-PerrorProneDisable'
+
+        when:
+        def suppressMessage = Throwables.getRootCause(runTasksWithFailure('compileAllErrorProne', '-PerrorProneDisable', '-PerrorProneSuppress').failure).message
+
+        then:
+        suppressMessage.contains '-PerrorProneDisable'
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
We had a bot internally that had disabled error prone globally. A task the bot did tried to apply and suppress errorprones while disabled. Rather than alerting the user about this, it just silently didn't run the errorprones.

## After this PR
==COMMIT_MSG==
Throw exception when `-PerrorProneDisable` is combined with `-PerrorProneApply` or `-PerrorProneSuppress`
==COMMIT_MSG==

## Possible downsides?
It could be nice to allow people to globally suppress errorprones then "opt in" of apply or suppress is requested. But this is kinda spooky behaviour; I'd rather just people were explicit.
