### PR TITLE
Ensure gradle-errorprone-plugin is api

### DIFF
--- a/changelog/@unreleased/pr-51.v2.yml
+++ b/changelog/@unreleased/pr-51.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`gradle-errorprone-plugin` is now an API dependency, allowing `ErrorProneOptions`
+    to be used easily.'
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/51

--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -5,7 +5,8 @@ apply plugin: 'com.palantir.gradle-plugin-testing'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 
 dependencies {
-    implementation 'net.ltgt.gradle:gradle-errorprone-plugin'
+    api 'net.ltgt.gradle:gradle-errorprone-plugin'
+    
     implementation 'org.ow2.asm:asm'
     implementation 'com.palantir.gradle.utils:environment-variables'
 


### PR DESCRIPTION
## Before this PR
`ErrorProneOptions` is used in our api in the extension, but it's not listed as an api dependency, so people need to 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`gradle-errorprone-plugin` is now an API dependency, allowing `ErrorProneOptions` to be used easily.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

