### PR TITLE
Ensure Suggestion level checks do not get suppressed

### DIFF
--- a/changelog/@unreleased/pr-61.v2.yml
+++ b/changelog/@unreleased/pr-61.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure Suggestion level checks do not get suppressed
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/61

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -71,7 +71,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 //   5. Run the tests as well
                 // If the variable below is true the tests will fail as the compilation process will try to
                 // attach to a non-existent debugger. Set it to false before you push any code.
-                boolean debuggingErrorPrones = false
+                boolean debuggingErrorPrones = true
                 if (debuggingErrorPrones) {
                     it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
                         @Override
@@ -698,7 +698,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         def stderr = runTasksWithFailure('compileAllErrorProne').standardError
         stderr.contains('[FieldCanBeFinal]')
 
-        when: 'the check is run at the default SUGGESTION level, and then automated suppressions are applied'
+        when: 'the check is run at the default SUGGESTION level, and then automated suppressions are not applied'
         buildFile.text = originalBuildFile
 
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
@@ -919,6 +919,26 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
         when:
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=Other')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            @SuppressWarnings("for-rollout:Test")
+            public final class App {}
+        '''.stripIndent(true)
+    }
+
+    def 'does not suppress RemoveRolloutSuppressions'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            @SuppressWarnings("for-rollout:Test")
+            public final class App {}
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
         // language=Java

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -71,7 +71,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
                 //   5. Run the tests as well
                 // If the variable below is true the tests will fail as the compilation process will try to
                 // attach to a non-existent debugger. Set it to false before you push any code.
-                boolean debuggingErrorPrones = true
+                boolean debuggingErrorPrones = false
                 if (debuggingErrorPrones) {
                     it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
                         @Override
@@ -700,6 +700,14 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
 
         when: 'the check is run at the default SUGGESTION level, and then automated suppressions are not applied'
         buildFile.text = originalBuildFile
+        // language=Gradle
+        buildFile << '''
+            tasks.withType(JavaCompile).configureEach {
+                // This is disabled by default in error-prone, so enable it
+                //   https://github.com/google/error-prone/blob/04f05c24882152d3c84f4caf9345efd15859b928/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java#L1191
+                options.errorprone.enable('FieldCanBeFinal')
+            }
+        '''.stripIndent(true)
 
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -957,6 +957,25 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
+    def 'RemoveRolloutSuppressions can remove itself'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            @SuppressWarnings("for-rollout:RemoveRolloutSuppressions")
+            public final class App {}
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=RemoveRolloutSuppressions')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App {}
+        '''.stripIndent(true)
+    }
+
     @Override
     ExecutionResult runTasksSuccessfully(String... tasks) {
         def result = runTasks(tasks)

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -46,7 +46,9 @@ import javax.lang.model.element.Name;
         // This needs to be SUGGESTION so that error prone won't try to apply the check in normal operations
         // When requested, we will directly enable it in the command line arguments
         severity = BugPattern.SeverityLevel.SUGGESTION,
-        summary = "Remove for-rollout suppression warnings")
+        summary = "Remove for-rollout suppression warnings",
+        // Make it unsuppressible so that it can actually remove itself
+        suppressionAnnotations = {})
 public final class RemoveRolloutSuppressions extends BugChecker implements BugChecker.AnnotationTreeMatcher {
 
     public static final String ARGUMENT = "SuppressibleErrorProne:RemoveForRolloutWarnings";

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -18,6 +18,7 @@ package com.palantir.suppressibleerrorprone;
 
 // CHECKSTYLE:OFF
 
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.AnnotationTree;
@@ -64,6 +65,12 @@ public final class VisitorStateModifications {
 
         if (shouldPreferDefaultSuggestedFixesForThisCheck && checkHasSuggestedFixes) {
             return description;
+        }
+
+        // If the check is a suggestion, we don't want to auto-suppress it, so we return no match (such that it also
+        //    doesn't auto-fix it if not requested, which is caught in the above)
+        if (visitorState.severityMap().get(description.checkName).equals(SeverityLevel.SUGGESTION)) {
+            return Description.NO_MATCH;
         }
 
         // We can't just use visitorState.getPath() because there are checks that do not emit Descriptions


### PR DESCRIPTION
## Before this PR
As it turns out, the plugin was incorrectly suppressing Suggestion level checks. There was a test that verified it, but it was in fact testing on a disabled check (which was disabled by default in error-prone).

This caused us to automatically add `for-rollout: RemoveRolloutSuppressions` suppressions to any existing suppressions with a for-rollout suppression.

Instead, we should properly ignore Suggestion checks, and also make it possible for the check to remove the incorrectly added annotations (which can be done by making the check unsuppressible).

## After this PR
==COMMIT_MSG==
Ensure Suggestion level checks do not get suppressed
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

