### PR TITLE
Avoid `Note: [RemoveRolloutSuppressions]` in unrelated error messages

### DIFF
--- a/changelog/@unreleased/pr-67.v2.yml
+++ b/changelog/@unreleased/pr-67.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Avoid `Note: [RemoveRolloutSuppressions]` in unrelated error messages'
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/67

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -218,13 +218,17 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                     return List.of(
                             "-XepPatchLocation:IN_PLACE",
                             "-XepPatchChecks:RemoveRolloutSuppressions",
-                            "-XepOpt:SuppressibleErrorProne:RemoveForRolloutWarnings="
+                            "-XepOpt:SuppressibleErrorProne:RemoveRolloutSuppressions="
                                     + String.join(",", suppressionsToRemove));
                 }
             });
 
             return;
         }
+
+        // If we're not removing suppressions, disable it to avoid having `Note: [RemoveRolloutSuppressions]` in
+        // unrelated error messages as it's a suggestion level check.
+        errorProneOptions.disable("RemoveRolloutSuppressions");
 
         if (isSuppressing(project)) {
             errorProneOptions.getErrorproneArgumentProviders().add(new CommandLineArgumentProvider() {

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package com.palantir.gradle.suppressibleerrorprone
 
+import com.google.common.base.Throwables
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
-import org.assertj.core.util.Throwables
 import spock.lang.Unroll
 
 class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
@@ -974,6 +974,25 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
             package app;
             public final class App {}
         '''.stripIndent(true)
+    }
+
+    def 'RemoveRolloutSuppressions does not appear as a Note: [RemoveRolloutSuppressions] in unrelated errors'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("for-rollout:NullAway")
+                public static void method() {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        def rootCauseMessage = Throwables.getRootCause(runTasksWithFailure('compileAllErrorProne').failure).message
+
+        then:
+        !rootCauseMessage.contains('[RemoveRolloutSuppressions]')
     }
 
     @Override

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -51,7 +51,7 @@ import javax.lang.model.element.Name;
         suppressionAnnotations = {})
 public final class RemoveRolloutSuppressions extends BugChecker implements BugChecker.AnnotationTreeMatcher {
 
-    public static final String ARGUMENT = "SuppressibleErrorProne:RemoveForRolloutWarnings";
+    public static final String ARGUMENT = "SuppressibleErrorProne:RemoveRolloutSuppressions";
 
     @Override
     public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
@@ -62,8 +62,8 @@ public final class RemoveRolloutSuppressions extends BugChecker implements BugCh
 
         Set<String> suppressionsToRemove = state.errorProneOptions().getFlags().getSetOrEmpty(ARGUMENT).stream()
                 // If no check is specified in the command line argument, the error prone option will look like
-                //   "-XepOpt:SuppressibleErrorProne:RemoveForRolloutWarnings=" which will match to just an empty string
-                // In this case, we actually want to remove all the suppressions
+                //   "-XepOpt:SuppressibleErrorProne:RemoveRolloutSuppressions=" which will match to just an empty
+                // string. In this case, we actually want to remove all the suppressions
                 .filter(s -> !s.isEmpty())
                 .map(s -> CommonConstants.AUTOMATICALLY_ADDED_PREFIX + s)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
## Before this PR
People are getting confused by `Note: [RemoveRolloutSuppressions]` appearing in unrelated error messages, thinking this was the actual error message:

```
Compilation failed; see the compiler output below.
src/main/java/app/App.java:4: Note: [RemoveRolloutSuppressions] Remove for-rollout suppression warnings
    @SuppressWarnings("for-rollout:NullAway")
    ^
    (see https://github.com/palantir/suppressible-error-prone)
  Did you mean 'public final class App {'?
src/main/java/app/App.java:6: error: [ArrayToString] Calling toString on an array does not provide useful information
        System.out.println(new int[3].toString());
                           ^
    (see https://errorprone.info/bugpattern/ArrayToString)
  Did you mean 'System.out.println(Arrays.toString(new int[3]));'?
1 error
```

This is because we have `RemoveRolloutSuppressions` as an enabled Suggestion level check which we use to remove rollout suppressions.

## After this PR
==COMMIT_MSG==
Avoid `Note: [RemoveRolloutSuppressions]` in unrelated error messages
==COMMIT_MSG==

We just disable the check now if we don't need it, which stops these issues.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

