### PR TITLE
Allow patching specific unsuppressed checks when using errorProneRemoveRollout

### DIFF
--- a/changelog/@unreleased/pr-69.v2.yml
+++ b/changelog/@unreleased/pr-69.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow patching specific unsuppressed checks when using errorProneRemoveRollout
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/69

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -19,8 +19,10 @@ package com.palantir.gradle.suppressibleerrorprone;
 import com.palantir.gradle.suppressibleerrorprone.transform.ModifyErrorProneCheckApi;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import net.ltgt.gradle.errorprone.CheckSeverity;
@@ -75,15 +77,18 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 .orElseThrow(
                         () -> new RuntimeException("SuppressibleErrorPronePlugin implementation version not found"));
 
-        // When auto-suppressing, there are two stages:
-        // 1. The first runs a bytecode patched version of errorprone (via an
-        //    artifact transform) that intercepts every error from every check and adds a custom fix, a
-        //    @RepeatableSuppressWarnings annotation to the relevant statement/method/field/class.
-        // 2. The second stage runs a single errorprone check: SuppressWarningsCoalesce, which will combine all
-        //    the @RepeatableSuppressWarnings and @SuppressWarnings annotations into one normal @SuppressWarnings
-        //    annotation.
+        // Don't need to consider the custom suppression logic if we're going to remove the suppressions anyway
+        if (!isRemovingSuppressions(project)) {
+            // When auto-suppressing, there are two stages:
+            // 1. The first runs a bytecode patched version of errorprone (via an
+            //    artifact transform) that intercepts every error from every check and adds a custom fix, a
+            //    @RepeatableSuppressWarnings annotation to the relevant statement/method/field/class.
+            // 2. The second stage runs a single errorprone check: SuppressWarningsCoalesce, which will combine all
+            //    the @RepeatableSuppressWarnings and @SuppressWarnings annotations into one normal @SuppressWarnings
+            //    annotation.
 
-        setupErrorProneArtifactTransform(project);
+            setupErrorProneArtifactTransform(project);
+        }
 
         project.getConfigurations().named(ErrorPronePlugin.CONFIGURATION_NAME).configure(errorProneConfiguration -> {
             // Required so that we can run the runtime parts of the errorprone patching in suppressing stage 1 and
@@ -214,10 +219,14 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 @Override
                 public Iterable<String> asArguments() {
                     List<String> suppressionsToRemove = checksToRemoveSuppressionsFor(project);
+                    Set<String> checksToPatch = new HashSet<>();
+                    checksToPatch.add("RemoveRolloutSuppressions");
+                    // TODO(aldexis): Should we only do this if a specific argument is present?
+                    checksToPatch.addAll(suppressionsToRemove);
 
                     return List.of(
                             "-XepPatchLocation:IN_PLACE",
-                            "-XepPatchChecks:RemoveRolloutSuppressions",
+                            "-XepPatchChecks:" + String.join(",", checksToPatch),
                             "-XepOpt:SuppressibleErrorProne:RemoveRolloutSuppressions="
                                     + String.join(",", suppressionsToRemove));
                 }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -82,14 +82,8 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
         // Note that this means we need to handle the requested patches with care, so as to not apply patches to
         //   checks that are suppressed with for-rollout, but for which we're not going to remove the suppressions.
         if (!isRemovingSuppressions(project)) {
-            // When auto-suppressing, there are two stages:
-            // 1. The first runs a bytecode patched version of errorprone (via an
-            //    artifact transform) that intercepts every error from every check and adds a custom fix, a
-            //    @RepeatableSuppressWarnings annotation to the relevant statement/method/field/class.
-            // 2. The second stage runs a single errorprone check: SuppressWarningsCoalesce, which will combine all
-            //    the @RepeatableSuppressWarnings and @SuppressWarnings annotations into one normal @SuppressWarnings
-            //    annotation.
-
+            // When auto-suppressing, the logic will run a bytecode patched version of errorprone
+            // (via an artifact transform) that intercepts every error from every check and adds a custom fix
             setupErrorProneArtifactTransform(project);
         }
 
@@ -226,17 +220,28 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                     Set<String> checksToPatch = new HashSet<>();
                     checksToPatch.add("RemoveRolloutSuppressions");
 
-                    // If we're also applying suggested patches, we want to make sure that these are a subset of
-                    //   the checks we're removing suppressions for.
-                    // Otherwise, we might apply fixes for a check that we're not removing the suppression for, if
-                    //   suppressed using a for-rollout suppression (because we're not applying the for-rollout hack)
                     if (isApplyingSuggestedPatches(project)) {
-                        Set<String> suppressionsToRemoveSet = new HashSet<>(suppressionsToRemove);
                         List<String> extraChecksToPatch =
                                 checksToApplySuggestedPatchesFor(extension, javaCompile, errorProneOptions);
-                        if (extraChecksToPatch.stream().anyMatch(check -> !suppressionsToRemoveSet.contains(check))) {
-                            throw new IllegalStateException(
-                                    "Checks to patch must be a subset of the checks to remove suppressions for");
+
+                        // If we're also applying suggested patches, we want to make sure that these are a subset of
+                        //   the checks we're removing suppressions for.
+                        // Otherwise, we might apply fixes for a check that we're not removing the suppression for, if
+                        //   suppressed using a for-rollout suppression (because we're not applying the for-rollout fix)
+                        // However, if we're not specifiying specific checks to remove the suppressions for, we're
+                        //   going to remove all the for-rollout suppressions, thus can accept any and all checks to
+                        //   apply patches for
+                        if (!suppressionsToRemove.isEmpty()) {
+                            Set<String> suppressionsToRemoveSet = new HashSet<>(suppressionsToRemove);
+                            List<String> checksNotInSuppressionRemovals = extraChecksToPatch.stream()
+                                    .filter(check -> !suppressionsToRemoveSet.contains(check))
+                                    .toList();
+                            if (!checksNotInSuppressionRemovals.isEmpty()) {
+                                throw new IllegalStateException(
+                                        "Checks to patch must be a subset of the checks to remove suppressions for. "
+                                                + "Checks not in the errorProneRemoveRollout list: "
+                                                + checksNotInSuppressionRemovals);
+                            }
                         }
                         checksToPatch.addAll(extraChecksToPatch);
                     }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -61,9 +61,9 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                     + "-PerrorProneApply, -PerrorProneSuppress or -PerrorProneRemoveRollout");
         }
 
-        if (isRemovingSuppressions(project) && (isSuppressing(project) || isApplyingSuggestedPatches(project))) {
-            throw new IllegalStateException("-PerrorProneRemoveRollout cannot be used at the same time as "
-                    + "-PerrorProneApply or -PerrorProneSuppress");
+        if (isRemovingSuppressions(project) && isSuppressing(project)) {
+            throw new IllegalStateException(
+                    "-PerrorProneRemoveRollout cannot be used at the same time as " + "-PerrorProneSuppress");
         }
 
         project.getPluginManager().apply(ErrorPronePlugin.class);
@@ -219,10 +219,24 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 @Override
                 public Iterable<String> asArguments() {
                     List<String> suppressionsToRemove = checksToRemoveSuppressionsFor(project);
+
                     Set<String> checksToPatch = new HashSet<>();
                     checksToPatch.add("RemoveRolloutSuppressions");
-                    // TODO(aldexis): Should we only do this if a specific argument is present?
-                    checksToPatch.addAll(suppressionsToRemove);
+
+                    // If we're also applying suggested patches, we want to make sure that these are a subset of
+                    //   the checks we're removing suppressions for.
+                    // Otherwise, we might apply fixes for a check that we're not removing the suppression for, if
+                    //   suppressed using a for-rollout suppression (because we're not applying the for-rollout hack)
+                    if (isApplyingSuggestedPatches(project)) {
+                        Set<String> suppressionsToRemoveSet = new HashSet<>(suppressionsToRemove);
+                        List<String> extraChecksToPatch =
+                                checksToApplySuggestedPatchesFor(extension, javaCompile, errorProneOptions);
+                        if (extraChecksToPatch.stream().anyMatch(check -> !suppressionsToRemoveSet.contains(check))) {
+                            throw new IllegalStateException(
+                                    "Checks to patch must be a subset of the checks to remove suppressions for");
+                        }
+                        checksToPatch.addAll(extraChecksToPatch);
+                    }
 
                     return List.of(
                             "-XepPatchLocation:IN_PLACE",

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -63,7 +63,7 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
 
         if (isRemovingSuppressions(project) && isSuppressing(project)) {
             throw new IllegalStateException(
-                    "-PerrorProneRemoveRollout cannot be used at the same time as " + "-PerrorProneSuppress");
+                    "-PerrorProneRemoveRollout cannot be used at the same time as -PerrorProneSuppress");
         }
 
         project.getPluginManager().apply(ErrorPronePlugin.class);
@@ -77,7 +77,10 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 .orElseThrow(
                         () -> new RuntimeException("SuppressibleErrorPronePlugin implementation version not found"));
 
-        // Don't need to consider the custom suppression logic if we're going to remove the suppressions anyway
+        // If we're going to remove suppressions, and possibly apply patches, we don't want to apply the custom
+        //   logic for for-rollout suppressions.
+        // Note that this means we need to handle the requested patches with care, so as to not apply patches to
+        //   checks that are suppressed with for-rollout, but for which we're not going to remove the suppressions.
         if (!isRemovingSuppressions(project)) {
             // When auto-suppressing, there are two stages:
             // 1. The first runs a bytecode patched version of errorprone (via an

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -976,7 +976,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
-    def 'can patch targeted patchable checks using -PerrorProneRemoveRollout, even if suppressed for rollout'() {
+    def 'can patch checks while using -PerrorProneRemoveRollout, even if suppressed for rollout'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
@@ -989,7 +989,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString', '-PerrorProneApply=ArrayToString')
 
         then:
         // language=Java
@@ -1005,7 +1005,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
-    def 'does not patch patchable checks using -PerrorProneRemoveRollout, if suppressed normally'() {
+    def 'does not patch checks while using -PerrorProneRemoveRollout, if suppressed normally'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
@@ -1018,7 +1018,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString', '-PerrorProneApply=ArrayToString')
 
         then:
         // language=Java
@@ -1033,7 +1033,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
-    def 'can patch patchable checks using -PerrorProneRemoveRollout, if not suppressed'() {
+    def 'can patch checks while using -PerrorProneRemoveRollout, if not suppressed'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
@@ -1045,7 +1045,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString', '-PerrorProneApply=ArrayToString')
 
         then:
         // language=Java
@@ -1073,7 +1073,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=NullAway')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=NullAway', '-PerrorProneApply=NullAway')
 
         then:
         // language=Java
@@ -1087,7 +1087,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
-    def 'errorProneRemoveRollout does not patch if no specific check is targeted'() {
+    def 'errorProneRemoveRollout does not patch by itself'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
@@ -1100,7 +1100,35 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def 'errorProneRemoveRollout does not patch if specific check is not selected'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            @SuppressWarnings("for-rollout:Test")
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString,Test', '-PerrorProneApply=Test')
 
         then:
         // language=Java

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1142,6 +1142,71 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
+    def 'can patch specific checks even if errorProneRemoveRollout argument is empty'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout', '-PerrorProneApply=ArrayToString')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import java.util.Arrays;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(Arrays.toString(new int[3]));
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def 'can patch configured checks even if errorProneRemoveRollout argument is empty'() {
+        // language=Gradle
+        buildFile << '''
+            suppressibleErrorProne {
+                patchChecks.add('ArrayToString')
+            }
+        '''.stripIndent(true)
+
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout', '-PerrorProneApply')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import java.util.Arrays;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(Arrays.toString(new int[3]));
+                }
+            }
+        '''.stripIndent(true)
+    }
+
     def 'RemoveRolloutSuppressions does not appear as a Note: [RemoveRolloutSuppressions] in unrelated errors'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -976,6 +976,144 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
+    def 'can patch targeted patchable checks using -PerrorProneRemoveRollout, even if suppressed for rollout'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import java.util.Arrays;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(Arrays.toString(new int[3]));
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def 'does not patch patchable checks using -PerrorProneRemoveRollout, if suppressed normally'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App {
+                @SuppressWarnings("ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def 'can patch patchable checks using -PerrorProneRemoveRollout, if not suppressed'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ArrayToString')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import java.util.Arrays;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(Arrays.toString(new int[3]));
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def 'errorProneRemoveRollout does not patch unrelated checks'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=NullAway')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def 'errorProneRemoveRollout does not patch if no specific check is targeted'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayToString")
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    System.out.println(new int[3].toString());
+                }
+            }
+        '''.stripIndent(true)
+    }
+
     def 'RemoveRolloutSuppressions does not appear as a Note: [RemoveRolloutSuppressions] in unrelated errors'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ You can also use to remove all or some of the for-rollout suppression warnings:
 
 ```
 ./gradlew compileAllErrorProne -PerrorProneRemoveRollout
+# The below will also automatically apply the suggested fixes for the checks, if any
 ./gradlew compileAllErrorProne -PerrorProneRemoveRollout=Check,OtherCheck
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -127,8 +127,13 @@ You can also use to remove all or some of the for-rollout suppression warnings:
 
 ```
 ./gradlew compileAllErrorProne -PerrorProneRemoveRollout
-# The below will also automatically apply the suggested fixes for the checks, if any
 ./gradlew compileAllErrorProne -PerrorProneRemoveRollout=Check,OtherCheck
+```
+
+This can also be combined with `-PerrorProneApply` to apply suggested fixes for the checks you are removing the suppressions for:
+
+```
+./gradlew compileAllErrorProne -PerrorProneRemoveRollout=Check,OtherCheck -PerrorProneApply=Check
 ```
 
 


### PR DESCRIPTION
## Before this PR
When removing for-rollout suppressions, we aren't actually applying fixes that we might (e.g. [SafeLoggingPropagation](https://github.com/palantir/gradle-baseline/blob/develop/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java)).

This leads to more friction than necessary, as these will now fail the compilation, but could be automatically fixed.

## After this PR
==COMMIT_MSG==
Allow patching specific unsuppressed checks when using errorProneRemoveRollout
==COMMIT_MSG==

## Possible downsides?
- ~It might be confusing that we're automatically fixing these without using a dedicated argument~
- It might be confusing if pull requests are being opened that typically require manual intervention (and mention it as such in their body), but instead are automatically fixed and merged.

