### PR TITLE
[DO NOT MERGE] Reproduce bug where remove+apply doesn't work

### DIFF
--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1005,6 +1005,37 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
     }
 
+    def 'can patch checks while using -PerrorProneRemoveRollout, which also add annotations as fixes'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                @SuppressWarnings("for-rollout:TestBugPattern")
+                public Object toFix() {
+                    System.out.println("Test");
+                    return null;
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=TestBugPattern', '-PerrorProneApply=TestBugPattern')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import javax.annotation.Nullable;
+            public final class App {
+                @Nullable public Object toFix() {
+                    System.out.println("Test");
+                    return null;
+                }
+            }
+        '''.stripIndent(true)
+    }
+
     def 'does not patch checks while using -PerrorProneRemoveRollout, if suppressed normally'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -131,7 +131,7 @@ public final class RemoveRolloutSuppressions extends BugChecker implements BugCh
 
         @Override
         public CoalescePolicy getCoalescePolicy() {
-            return CoalescePolicy.REJECT;
+            return CoalescePolicy.EXISTING_FIRST;
         }
 
         @Override

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/TestBugPattern.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/TestBugPattern.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.suppressibleerrorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.MethodTree;
+
+@AutoService(BugChecker.class)
+@BugPattern(severity = BugPattern.SeverityLevel.ERROR, summary = "")
+public final class TestBugPattern extends BugChecker implements BugChecker.MethodTreeMatcher {
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        if (tree.getName().contentEquals("toFix")) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            String qualifiedAnnotation = SuggestedFixes.qualifyType(state, fix, "javax.annotation.Nullable");
+            fix.prefixWith(tree, String.format("@%s ", qualifiedAnnotation));
+            return buildDescription(tree).addFix(fix.build()).build();
+        }
+        return Description.NO_MATCH;
+    }
+}


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/suppressible-error-prone/pull/69 introduced the possibility to remove the for-rollout suppressions at the same time as applying the fixes for said suppressions.

It turns out that this doesn't seem to work properly, if the fix is to apply another annotation.

## After this PR
==COMMIT_MSG==
Reproduce bug where remove+apply doesn't work
==COMMIT_MSG==

Currently, this PR only reproduces the bug, as I haven't been able to figure out how to fix it (tried all different CoalescePolicy and none seem to help)

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

