### PR TITLE
Ensure all errorprone dependencies have the same version

### DIFF
--- a/changelog/@unreleased/pr-97.v2.yml
+++ b/changelog/@unreleased/pr-97.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure all errorprone dependencies have the same version
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/97

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -32,6 +32,9 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -155,13 +158,29 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
             // and so where we must put our transform. annotationProcessor extendsFrom errorprone.
             project.getConfigurations()
                     .named(sourceSet.getAnnotationProcessorConfigurationName())
-                    .configure(errorProneConfiguration -> {
-                        errorProneConfiguration
+                    .configure(annotationProcessor -> {
+                        annotationProcessor
                                 .getDependencies()
                                 .add(project.getDependencies().create("com.google.errorprone:error_prone_check_api"));
-                        errorProneConfiguration.getAttributes().attribute(suppressible, true);
+                        annotationProcessor.getAttributes().attribute(suppressible, true);
                     });
+
+            project.getDependencies().getComponents().all(ConsistentErrorPronePlatformRule.class);
         });
+    }
+
+    static final class ConsistentErrorPronePlatformRule implements ComponentMetadataRule {
+        private static final String ERRORPRONE_GROUP = "com.google.errorprone";
+
+        @Override
+        public void execute(ComponentMetadataContext context) {
+            ModuleVersionIdentifier id = context.getDetails().getId();
+            if (!id.getGroup().equals(ERRORPRONE_GROUP)) {
+                return;
+            }
+
+            context.getDetails().belongsTo("%s:_:%s".formatted(ERRORPRONE_GROUP, id.getVersion()));
+        }
     }
 
     private void configureJavaCompile(Project project, JavaCompile javaCompile) {

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -169,6 +169,14 @@ public final class SuppressibleErrorPronePlugin implements Plugin<Project> {
         });
     }
 
+    /**
+     * Stolen wholesale from GCV:
+     *      https://github.com/palantir/gradle-consistent-versions/blob/8318ac29e81b6a77ed9ec223b2024cb7a61c7175/
+     *      src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java#L294-L305
+     * This sets up a "virtual platform" that all errorprone dependencies are bound to. It means they will all have
+     * the same version. It's very similar to adding `com.google.errorprone:* = ...` to the `versions.props` file
+     * (in fact it's the same thing), except we are doing this from a gradle plugin.
+     */
     static final class ConsistentErrorPronePlatformRule implements ComponentMetadataRule {
         private static final String ERRORPRONE_GROUP = "com.google.errorprone";
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1226,6 +1226,34 @@ class SuppressibleErrorPronePluginIntegrationTest extends IntegrationSpec {
         !rootCauseMessage.contains('[RemoveRolloutSuppressions]')
     }
 
+    def 'error-prone dependencies have versions bound together by a virtual platform'() {
+        setup: 'when an error-prone dependency is forced to certain version'
+        // language=Gradle
+        buildFile << '''
+            configurations.named('annotationProcessor') {
+                resolutionStrategy {
+                   force 'com.google.errorprone:error_prone_annotation:2.3.4'
+                }
+            }
+            
+            tasks.register('printErrorProneVersions') {
+                inputs.files(configurations.named('annotationProcessor'))
+                doLast {
+                    inputs.files.files.each {
+                        println("ERROR-PRONE: ${it.name}")
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        def output = runTasksSuccessfully('printErrorProneVersions').standardOutput
+
+        then: 'every single error-prone dependency has the same version'
+        output.contains('ERROR-PRONE: error_prone_annotation-2.3.4.jar')
+        output.contains('ERROR-PRONE: error_prone_core-2.3.4.jar')
+    }
+
     @Override
     ExecutionResult runTasksSuccessfully(String... tasks) {
         def result = runTasks(tasks)


### PR DESCRIPTION
## Before this PR
We have had two separate issues where error-prone dependencies in the compiler classpath (`annotationProcessor`) have been at different versions resulting in `ClassNotFoundError` or `NoSuchMethodError`s:

**First Issue**

```
Caused by: java.lang.ClassNotFoundException: com.google.errorprone.annotations.ImmutableTypeParameter
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
```

Caused by `error_prone_core` being at 2.38.0 while `error_prone_annotations` was forced down to 2.36.0 by a plugin's `enforcedPlatform`:

![69c77179-ade6-4787-a4bc-7875110be920](https://github.com/user-attachments/assets/b0e5fe55-c814-40f3-a280-32327addcee9)

**Second Issue**

```
     java.lang.NoSuchMethodError: 'com.google.errorprone.util.ErrorProneScope com.google.errorprone.util.ASTHelpers.scope(com.sun.tools.javac.code.Scope)'
        at com.google.errorprone.bugpatterns.ClassInitializationDeadlock.matchClass(ClassInitializationDeadlock.java:64)
```

This is actually a different issue where baseline is expecting error-prone 2.36.0 but it gets upgraded to 2.38.0. However, even here the versions of error-prone jars are different, which is likely to lead to issues:

<img width="416" alt="Screenshot 2025-06-24 at 17 44 22" src="https://github.com/user-attachments/assets/6a77df95-8d06-4793-88e7-557bd86dc7db" />

## After this PR
==COMMIT_MSG==
Ensure all errorprone dependencies have the same version
==COMMIT_MSG==

We do this using a `ComponentMetadataRule` and virtual platform, like GCV does for star dependencies. This is essentially the same as adding the following to `versions.props` for all consuming projects, but directly via Gradle:

```
com.google.errorprone:* = ...
```

For the First Issue above, this is the result - all the versions are the same:

<img width="431" alt="Screenshot 2025-06-24 at 18 00 59" src="https://github.com/user-attachments/assets/ea309cae-7a4a-434c-8da0-32dddd313f1f" />

...and it says why (due to the platform):

<img width="423" alt="Screenshot 2025-06-24 at 18 01 07" src="https://github.com/user-attachments/assets/a459621f-3755-4f3e-9a19-da626366f4b0" />
 

## Possible downsides?
I can't find a way to add a more specific reason for this (ie saying it comes from suppressible-error-prone) - but there is the platform explanation at least.

