### PR TITLE
Fix severity check

### DIFF
--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -69,7 +69,7 @@ public final class VisitorStateModifications {
 
         // If the check is a suggestion, we don't want to auto-suppress it, so we return no match (such that it also
         //    doesn't auto-fix it if not requested, which is caught in the above)
-        if (visitorState.severityMap().get(description.checkName).equals(SeverityLevel.SUGGESTION)) {
+        if (visitorState.severityMap().get(description.checkName) == SeverityLevel.SUGGESTION) {
             return Description.NO_MATCH;
         }
 


### PR DESCRIPTION
This appear to be causing failures when [a check with an alternative name](https://github.com/google/error-prone/blob/4384ed81ed0b639307292bf5b12f820e8cfdd419/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java#L36-L37) is [disabled](https://github.com/google/error-prone/blob/4384ed81ed0b639307292bf5b12f820e8cfdd419/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java#L210).

https://github.com/google/error-prone/blob/4384ed81ed0b639307292bf5b12f820e8cfdd419/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java#L36

```
* What went wrong:
Execution failed for task ':<project>:compileIntegrationTestJava'.
> Compilation failed; see the compiler output below.
  <path>: error: An unhandled exception was thrown by the Error Prone static analysis plugin.
              KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getAlgorithm());
                                                            ^
       Please report this at https://github.com/google/error-prone/issues/new and include the following:
    
       error-prone version: 2.38.0
       BugPattern: InsecureCryptoUsage
       Stack Trace:
       java.lang.NullPointerException: Cannot invoke "com.google.errorprone.BugPattern$SeverityLevel.equals(Object)" because the return value of "java.util.Map.get(Object)" is null
    	at com.palantir.suppressibleerrorprone.VisitorStateModifications.interceptDescription(VisitorStateModifications.java:72)
```