### PR TITLE
Ensure running `-PerrorProneSuppress` and `-PerrorProneApply` at the same time do not resolve Configurations at configuration time

### DIFF
--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -52,3 +52,8 @@ tasks.withType(JavaCompile) {
 gradleTestUtils {
     gradleVersions = ['8.14.3']
 }
+
+moduleJvmArgs {
+    // Need so that debugging testkit gradle runs with configuration cache works
+    opens 'java.base/java.util', 'java.base/java.lang.invoke'
+}

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
@@ -17,8 +17,10 @@
 package com.palantir.gradle.suppressibleerrorprone.modes.common;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import one.util.streamex.EntryStream;
 
 /**
@@ -55,10 +57,20 @@ public interface CommonOptions {
         return commonOptions.stream().reduce(CommonOptions.empty(), CommonOptions::naivelyCombinedWith);
     }
 
-    default CommonOptions withExtraErrorProneCheckFlag(String key, String value) {
-        Map<String, String> map = new HashMap<>(extraErrorProneCheckOptions());
-        map.put(key, value);
-        return new DefaultCommonOptions(patchChecks(), map);
+    default CommonOptions withExtraErrorProneCheckFlag(String key, Supplier<String> value) {
+        return new CommonOptions() {
+            @Override
+            public PatchChecksOption patchChecks() {
+                return CommonOptions.this.patchChecks();
+            }
+
+            @Override
+            public Map<String, String> extraErrorProneCheckOptions() {
+                Map<String, String> map = new HashMap<>(CommonOptions.this.extraErrorProneCheckOptions());
+                map.put(key, value.get());
+                return Collections.unmodifiableMap(map);
+            }
+        };
     }
 
     /**
@@ -71,8 +83,4 @@ public interface CommonOptions {
     enum Empty implements CommonOptions {
         INSTANCE
     }
-
-    @SuppressWarnings("checkstyle:DesignForExtension")
-    record DefaultCommonOptions(PatchChecksOption patchChecks, Map<String, String> extraErrorProneCheckOptions)
-            implements CommonOptions {}
 }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/interferences/SuppressingAndApplyingInterference.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/interferences/SuppressingAndApplyingInterference.java
@@ -43,6 +43,6 @@ public final class SuppressingAndApplyingInterference extends SpecificModeInterf
         return suppress.naivelyCombinedWith(apply)
                 .withExtraErrorProneCheckFlag(
                         "SuppressibleErrorProne:PreferPatchChecks",
-                        apply.patchChecks().asCommaSeparated().orElse(""));
+                        () -> apply.patchChecks().asCommaSeparated().orElse(""));
     }
 }

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -41,6 +41,18 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         // language=Gradle
         buildFile << '''
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:3.1.0'
+                }
+            }
+            // Consistent versions checks we don't resolve configurations at configuration time and
+            // also interacts in many ways with dependencies
+            apply plugin: 'com.palantir.consistent-versions'
+
             apply plugin: 'com.palantir.suppressible-error-prone'
             apply plugin: 'java'
             
@@ -102,6 +114,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
             __TESTING=true
             __TESTING_CACHE_BUST_ERRORPRONE_TRANSFORM=true
         '''.stripIndent(true)
+
+        file('versions.lock')
     }
 
     def 'reports a failing error prone'() {
@@ -508,6 +522,55 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         buildFile << '''
             suppressibleErrorProne {
                 patchChecks.add('ArrayToString')
+            }
+        '''.stripIndent(true)
+
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+            public final class App {
+                public static void main(String[] args) {
+                    new int[3].toString();
+                    new int[3].equals(new int[3]);
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply', '-PerrorProneSuppress')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import java.util.Arrays;
+            public final class App {
+                @SuppressWarnings("for-rollout:ArrayEquals")
+                public static void main(String[] args) {
+                    Arrays.toString(new int[3]);
+                    new int[3].equals(new int[3]);
+                }
+            }
+        '''.stripIndent(true)
+
+        runTasksSuccessfully('compileAllErrorProne')
+    }
+
+    def 'can run apply and suppress at the same time with IfModuleIsUsed without exploding'() {
+        // language=Gradle
+        buildFile << '''
+            import com.palantir.gradle.suppressibleerrorprone.ConditionalPatchCheck 
+            import com.palantir.gradle.suppressibleerrorprone.IfModuleIsUsed
+            
+            suppressibleErrorProne {
+                conditionalPatchChecks.add(new ConditionalPatchCheck(
+                        new IfModuleIsUsed('com.fasterxml.jackson.core', 'jackson-core'), 'ArrayToString'))
+            }
+            
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
+                otherImplementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
             }
         '''.stripIndent(true)
 


### PR DESCRIPTION
## Before this PR
We noticed that our excavators stopped applying errorprone fixes. When running with both `-PerrorProneSuppress` and `-PerrorProneApply` at the same time, and a `IfModuleIsUsed` conditional patch check is registered (such as the one baseline uses), we end up resolving the compile classpath Configuration for each source set at configuration time, which GCV bans:

```
org.gradle.api.GradleException: Not allowed to resolve configuration ':project:integrationTestCompileClasspath' at configuration time (https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time). Please upgrade your plugins and double-check your gradle scripts (see stacktrace)
```

Our tests didn't catch this because:

1. We did not apply GCV in the tests
2. No test that has `-PerrorProneApply`, `-PerrorProneSuppress` **and** a `IfModuleIsUsed` conditional patch check.

The problem was in the `SuppressingAndApplyingInterference`: we calculate the value of the `patchChecks()` for the apply mode immediately rather than lazily, at configuration time. When an `IfModuleIsUsed` conditional patch check is in use, it will resolve the compile classpath Configuration to see whether the module is used when calculating `patchChecks()`, at configuration time, causing the GCV error.

## After this PR
==COMMIT_MSG==
Ensure running `-PerrorProneSuppress` and `-PerrorProneApply` at the same time when an `IfModuleIsUsed` conditional patch check is in use do not resolve Configurations at configuration time, which cause this error when used with `gradle-consistent-versions`:

```
org.gradle.api.GradleException: Not allowed to resolve configuration ':project:integrationTestCompileClasspath' at configuration time (https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time). Please upgrade your plugins and double-check your gradle scripts (see stacktrace)
```

==COMMIT_MSG==

Also verified ETE on an internal project.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

