### PR TITLE
fix annotation on anonymous class method param

### DIFF
--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -69,7 +69,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
             }
             
             dependencies {
-                errorprone 'com.google.errorprone:error_prone_core:2.31.0'
+                errorprone 'com.google.errorprone:error_prone_core:2.41.0'
             }
             
             tasks.withType(JavaCompile).configureEach {
@@ -1319,8 +1319,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
             }
 
             dependencies {
-                implementation 'com.google.guava:guava:33.1.0-jre'
-                otherImplementation 'com.google.guava:guava:33.1.0-jre'
+                errorprone "com.uber.nullaway:nullaway:0.12.9"
+                implementation 'com.google.guava:guava:33.5.0-jre'
+                otherImplementation 'com.google.guava:guava:33.5.0-jre'
             }
         '''.stripIndent(true)
 
@@ -1343,6 +1344,15 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                         public void onFailure(Throwable t) {}
                     };
                 }
+//                public static void dummy(String args) {
+//                    new int[3].toString();
+//                }
+//                static void log(Object x) {
+//                    System.out.println(x.toString());
+//                }
+//                static void foo() {
+//                    log(null);
+//                }
             }
         '''.stripIndent(true)
 
@@ -1350,28 +1360,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-        // language=Java
-        appJavaTextEquals '''
-            package app;
-
-            import com.google.common.util.concurrent.FutureCallback;
-
-            public final class App {
-                public static void main(String[] args) {
-                    FutureCallback<String> callback = new FutureCallback<String>() {
-                        @Override
-                        @SuppressWarnings("for-rollout:NullAway")
-                        public void onSuccess(String result) {
-                            // NullAway should flag this as an error since result could be null
-                            result.length();
-                        }
-
-                        @Override
-                        public void onFailure(Throwable t) {}
-                    };
-                }
-            }
-        '''.stripIndent(true)
+//        appJavaTextContains( '@SuppressWarnings("for-rollout:ArrayToString")')
+        appJavaTextContains( '@SuppressWarnings("for-rollout:NullAway")')
 
         runTasksSuccessfully('compileAllErrorProne')
     }

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1320,6 +1320,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
             dependencies {
                 implementation 'com.google.guava:guava:33.1.0-jre'
+                otherImplementation 'com.google.guava:guava:33.1.0-jre'
             }
         '''.stripIndent(true)
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1323,6 +1323,10 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                 implementation 'com.google.guava:guava:33.5.0-jre'
                 otherImplementation 'com.google.guava:guava:33.5.0-jre'
             }
+
+            tasks.withType(JavaCompile) {
+                options.errorprone.error('NullAway')
+            }
         '''.stripIndent(true)
 
         // language=Java

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1308,6 +1308,73 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         !output.contains('[RemoveRolloutSuppressions]')
     }
 
+    def 'can properly suppress NullAway in anonymous FutureCallback implementation'() {
+        // language=Gradle
+        buildFile << '''
+            suppressibleErrorProne {
+                configureEachErrorProneOptions {
+                    enable('NullAway')
+                    option('NullAway:AnnotatedPackages', 'app')
+                }
+            }
+
+            dependencies {
+                implementation 'com.google.guava:guava:33.1.0-jre'
+            }
+        '''.stripIndent(true)
+
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+
+            import com.google.common.util.concurrent.FutureCallback;
+
+            public final class App {
+                public static void main(String[] args) {
+                    FutureCallback<String> callback = new FutureCallback<String>() {
+                        @Override
+                        public void onSuccess(String result) {
+                            // NullAway should flag this as an error since result could be null
+                            result.length();
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t) {}
+                    };
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import com.google.common.util.concurrent.FutureCallback;
+
+            public final class App {
+                public static void main(String[] args) {
+                    FutureCallback<String> callback = new FutureCallback<String>() {
+                        @Override
+                        @SuppressWarnings("for-rollout:NullAway")
+                        public void onSuccess(String result) {
+                            // NullAway should flag this as an error since result could be null
+                            result.length();
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t) {}
+                    };
+                }
+            }
+        '''.stripIndent(true)
+
+        runTasksSuccessfully('compileAllErrorProne')
+    }
+
     def 'error-prone dependencies have versions bound together by a virtual platform'() {
         setup: 'when an error-prone dependency is forced to certain version'
         // language=Gradle

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1355,7 +1355,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-//        appJavaTextContains( '@SuppressWarnings("for-rollout:ArrayToString")')
         appJavaTextContains( '@SuppressWarnings("for-rollout:NullAway")')
 
         runTasksSuccessfully('compileAllErrorProne')

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1333,7 +1333,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
             public final class App {
                 public static void main(String[] args) {
-                    FutureCallback<String> callback = new FutureCallback<String>() {
+                    FutureCallback<String> callback = new FutureCallback<>() {
                         @Override
                         public void onSuccess(String result) {
                             // NullAway should flag this as an error since result could be null
@@ -1344,15 +1344,6 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                         public void onFailure(Throwable t) {}
                     };
                 }
-//                public static void dummy(String args) {
-//                    new int[3].toString();
-//                }
-//                static void log(Object x) {
-//                    System.out.println(x.toString());
-//                }
-//                static void foo() {
-//                    log(null);
-//                }
             }
         '''.stripIndent(true)
 


### PR DESCRIPTION
## Before this PR
Various excavator PRs that marked FutureCallback with NullAway are failing because the suppression isn't in the right place.  Maybe.

## After this PR
This PR doesn't fix the problem yet.  Only adds a test which shows the issue

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

