### PR TITLE
Fix apply + remove rollout overlapping with one another

### DIFF
--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     testImplementation 'commons-io:commons-io'
     testImplementation 'one.util:streamex'
     testImplementation 'com.palantir.gradle.plugintesting:configuration-cache-spec'
+    testImplementation 'com.palantir.javaformat:palantir-java-format'
 }
 
 gradlePlugin {

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -18,14 +18,18 @@ package com.palantir.gradle.suppressibleerrorprone
 
 
 import com.palantir.gradle.plugintesting.ConfigurationCacheSpec
+import com.palantir.javaformat.java.JavaFormatterOptions
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
 import spock.lang.Unroll
+import com.palantir.javaformat.java.Formatter
+
 
 class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec {
     // We need to put the source sets in a different directory that does not contain the any words that would hit
     // the errorprone excludedPathRegex, ie build in build/nebulatest
     static File nebulatestSourceSets = new File('nebulatestSourceSets/' + SuppressibleErrorPronePluginIntegrationTest.class.simpleName)
+    static Formatter formatter = Formatter.createFormatter(JavaFormatterOptions.builder().style(JavaFormatterOptions.Style.PALANTIR).build())
     File sourceSetRoot
     File mainSourceSet
     File otherSourceSet
@@ -40,7 +44,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
     //   5. Run the tests as well
     // If the variable below is true the tests will fail as the compilation process will try to
     // attach to a non-existent debugger. Set it to false before you push any code.
-    boolean debuggingErrorPrones = isJwdpLoaded()
+    boolean debuggingErrorPrones = false
 
     def setupSpec() {
         FileUtils.deleteDirectory(nebulatestSourceSets)
@@ -94,7 +98,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                     // These interfere with some tests, so disable them
                     // TODO(callumr): Rewrite the tests to use custom testing error-prones rather than built in checks
                     //                to make upgrading error-prone easier.
-                    disable('Varifier', 'ReturnValueIgnored', 'UnusedVariable', 'IdentifierName')
+                    disable('Varifier', 'ReturnValueIgnored', 'UnusedVariable', 'IdentifierName', 'UnusedMethod')
                     ignoreUnknownCheckNames = true
                 }
             }
@@ -112,7 +116,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                     it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
                         @Override
                         public Iterable<String> asArguments() {
-                            return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5006")
+                            return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005")
                         }
                     })
                 }
@@ -131,6 +135,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -153,6 +158,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public static void main(String[] args) {
@@ -169,6 +175,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         def erroringCode = '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -203,6 +210,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -216,7 +224,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         then:
         runTasksSuccessfully('compileAllErrorProne')
 
-        appJavaTextContains('Arrays.toString(new int[3])')
+        javaSourceContains('Arrays.toString(new int[3])')
     }
 
     def 'does not apply patches for a check if not added to the patchChecks list'() {
@@ -231,6 +239,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -242,7 +251,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJavaTextContains('new int[3].toString()')
+        javaSourceContains('new int[3].toString()')
     }
 
     def 'does not apply patches if there is nothing in patchChecks set'() {
@@ -256,6 +265,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -269,7 +279,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         stderr.contains('[ArrayToString]')
-        appJavaTextContains('new int[3].toString()')
+        javaSourceContains('new int[3].toString()')
     }
 
     def 'does not apply patches for check that was explicitly disabled'() {
@@ -287,6 +297,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -298,13 +309,14 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJavaTextContains('new int[3].toString()')
+        javaSourceContains('new int[3].toString()')
     }
 
     def 'can patch specific checks using -PerrorProneApply'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -317,14 +329,15 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply=ArrayToString,ArrayEquals')
 
         then:
-        appJavaTextContains('Arrays.toString(new int[3])')
-        appJavaTextContains('Arrays.equals(new int[2], new int[1])')
+        javaSourceContains('Arrays.toString(new int[3])')
+        javaSourceContains('Arrays.equals(new int[2], new int[1])')
     }
 
     def 'can suppress a failing check (even if not in patchChecks set)'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -336,7 +349,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then:
-        appJavaTextContains('@SuppressWarnings(\"for-rollout:ArrayToString\")')
+        javaSourceContains('@SuppressWarnings(\"for-rollout:ArrayToString\")')
 
 
         runTasksSuccessfully('compileAllErrorProne')
@@ -346,7 +359,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             import java.util.stream.Stream;
+            
             public class App {
                 void test() {
                     Stream.of(new Object()).forEach(o -> o.toString());
@@ -360,16 +375,18 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         then:
         // Suppression should be on the method, not the lambda parameter
         // language=Java
-        appJavaTextEquals("""
+        javaSourceIsSyntacticallyEqualTo """
             package app;
+            
             import java.util.stream.Stream;
+            
             public class App {
                 @SuppressWarnings("for-rollout:TestCheckNoSingleLetterVariable")
                 void test() {
                     Stream.of(new Object()).forEach(o -> o.toString());
                 }
             }
-        """.stripIndent(true))
+        """.stripIndent(true)
 
         // Verify the code still compiles after the suppression has been applied, as previous versions
         //   were adding the annotation to the lambda implicit parameter which is not valid java
@@ -380,7 +397,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             import java.util.stream.Stream;
+            
             public class App {
                 void test() {
                     Stream.of(new Object()).forEach((Object o) -> o.toString());
@@ -394,9 +413,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         then:
         // Suppression should be on the method, not the lambda parameter
         // language=Java
-        appJavaTextEquals("""
+        javaSourceIsSyntacticallyEqualTo("""
             package app;
+            
             import java.util.stream.Stream;
+            
             public class App {
                 @SuppressWarnings("for-rollout:TestCheckNoSingleLetterVariable")
                 void test() {
@@ -414,7 +435,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             import java.util.stream.Stream;
+            
             public class App {
                 void test() {
                     new Object() {
@@ -432,9 +455,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         then:
         // Suppression should be on the method, not the anonymous class
         // language=Java
-        appJavaTextEquals("""
+        javaSourceIsSyntacticallyEqualTo("""
             package app;
+            
             import java.util.stream.Stream;
+            
             public class App {
                 @SuppressWarnings("for-rollout:TestCheckNoSingleLetterVariable")
                 void test() {
@@ -456,6 +481,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public final String field = new int[3].toString();
 
@@ -484,8 +510,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public final String field = new int[3].toString();
@@ -535,6 +562,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public void variables() {
                     String variable;
@@ -547,8 +575,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 public void variables() {
                     @SuppressWarnings("for-rollout:UnusedVariable")
@@ -564,6 +593,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 static class exports {}
                 interface opens {}
@@ -578,17 +608,24 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
                 static class exports {}
+                
                 @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
                 interface opens {}
+                
                 @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
                 record provides(int cat) {}
+                
                 @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
-                enum to {;}
+                enum to {
+                    ;
+                }
+                
                 @SuppressWarnings("for-rollout:NamedLikeContextualKeyword")
                 @interface module {}
             }
@@ -602,11 +639,13 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("UnusedVariable")
                 public static void main(String[] args) {
                     App.Builder builder = new App.Builder(new int[3].toString());
                 }
+                
                 static class Builder {
                     Builder(Object object) {}
                 }
@@ -618,14 +657,16 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("UnusedVariable")
                 public static void main(String[] args) {
                     @SuppressWarnings("for-rollout:ArrayToString")
                     App.Builder builder = new App.Builder(new int[3].toString());
                 }
+                
                 static class Builder {
                     Builder(Object object) {}
                 }
@@ -647,6 +688,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -660,10 +702,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import java.util.Arrays;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayEquals")
                 public static void main(String[] args) {
@@ -696,6 +739,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -709,10 +753,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import java.util.Arrays;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayEquals")
                 public static void main(String[] args) {
@@ -730,6 +775,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -770,6 +816,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     Character.isJavaLetter('c'); // deprecated method
@@ -782,7 +829,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJavaTextContains('Arrays.toString(new int[3])')
+        javaSourceContains('Arrays.toString(new int[3])')
     }
 
     def 'can conditionally add patch checks'() {
@@ -800,6 +847,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -812,8 +860,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
 
         then:
-        appJavaTextContains('Arrays.toString(new int[3])')
-        appJavaTextContains('new int[2].equals(new int[1])')
+        javaSourceContains('Arrays.toString(new int[3])')
+        javaSourceContains('new int[2].equals(new int[1])')
     }
 
     def 'IfModuleIsUsed works properly'() {
@@ -837,6 +885,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -848,8 +897,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneApply')
 
         then:
-        appJavaTextContains('Arrays.toString(new int[3])')
-        appJavaTextContains('new int[2].equals(new int[1])')
+        javaSourceContains('Arrays.toString(new int[3])')
+        javaSourceContains('new int[2].equals(new int[1])')
     }
 
     def 'compileAllErrorProne only depends on compile tasks with errorprone enabled'() {
@@ -876,6 +925,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 private int field;
                 public App() {
@@ -913,7 +963,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress')
 
         then: 'it is not suppressed'
-        appJavaTextNotContains("SuppressWarnings")
+        javaSourceDoesNotContain("SuppressWarnings")
     }
 
     def 'WARNING level checks are suppressed'() {
@@ -929,6 +979,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String... args) {
                     new int[3].toString();
@@ -944,8 +995,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then: 'it is suppressed'
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public static void main(String... args) {
@@ -991,9 +1043,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         stderr2.contains('[NonCanonicalStaticImport]')
 
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             import static app.B.Inner;
+            
             public final class App {}
         '''.stripIndent(true)
     }
@@ -1002,6 +1056,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String... args) {}
             }
@@ -1034,6 +1089,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         def originalSource = '''
             package app;
+            
             public final class App {
                 public static void main(String... args) {
                     new int[3].toString();
@@ -1053,7 +1109,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         runTasksSuccessfully('compileAllErrorProne', *mode)
 
         then: 'changes are actually made, it was not up-to-date'
-        appJavaTextNotEquals originalSource
+        javaSourceIsSyntacticallyNotEqualTo originalSource
 
         where:
         mode << [
@@ -1082,6 +1138,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             @SuppressWarnings("for-rollout:Test")
             public final class App {}
         '''.stripIndent(true)
@@ -1091,8 +1148,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {}
         '''.stripIndent(true)
     }
@@ -1102,6 +1160,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             @SuppressWarnings("for-rollout:Test")
             public final class App {}
         '''.stripIndent(true)
@@ -1111,8 +1170,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {}
         '''.stripIndent(true)
     }
@@ -1122,6 +1182,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             @SuppressWarnings("for-rollout:Test")
             public final class App {}
         '''.stripIndent(true)
@@ -1131,8 +1192,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             @SuppressWarnings("for-rollout:Test")
             public final class App {}
         '''.stripIndent(true)
@@ -1142,6 +1204,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             @SuppressWarnings("for-rollout:Test")
             public final class App {}
         '''.stripIndent(true)
@@ -1151,8 +1214,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             @SuppressWarnings("for-rollout:Test")
             public final class App {}
         '''.stripIndent(true)
@@ -1162,6 +1226,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             @SuppressWarnings("for-rollout:RemoveRolloutSuppressions")
             public final class App {}
         '''.stripIndent(true)
@@ -1171,8 +1236,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {}
         '''.stripIndent(true)
     }
@@ -1181,6 +1247,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public static void main(String[] args) {
@@ -1194,10 +1261,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import java.util.Arrays;
+            
             public final class App {
                 public static void main(String[] args) {
                     Arrays.toString(new int[3]);
@@ -1233,21 +1301,52 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import javax.annotation.Nullable;
 
             public final class App {
-                @Nullable private Object fixme() {
+                @Nullable
+                private Object fixme() {
                     return null;
                 }
 
-                @Nullable private Object fixme(Object andMySuppressionHasWhiteSpaceAfterIt) {
+                @Nullable
+                private Object fixme(Object andMySuppressionHasWhiteSpaceAfterIt) {
                     return null;
                 }
                 
-                @Nullable private Integer fixme(Integer i) {
+                @Nullable
+                private Integer fixme(Integer i) {
+                    return null;
+                }
+            }
+        '''.stripIndent(true)
+    }
+
+    def '-PerrorProneSuppress then -PerrorProneRemoveRollout does not add newlines'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+
+            public final class App {
+                private Object fixme() {
+                    return null;
+                }
+            }
+        '''.stripIndent(true)
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneSuppress=ShouldBeNullable')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ShouldBeNullable')
+
+        then:
+        // language=Java
+        javaSourceIsSyntacticallyEqualTo '''
+            package app;
+
+            public final class App {
+                private Object fixme() {
                     return null;
                 }
             }
@@ -1259,6 +1358,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("ArrayToString")
                 public static void main(String[] args) {
@@ -1272,8 +1372,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("ArrayToString")
                 public static void main(String[] args) {
@@ -1287,6 +1388,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -1299,10 +1401,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import java.util.Arrays;
+            
             public final class App {
                 public static void main(String[] args) {
                     Arrays.toString(new int[3]);
@@ -1315,6 +1418,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -1327,8 +1431,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -1341,6 +1446,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public static void main(String[] args) {
@@ -1354,8 +1460,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -1382,8 +1489,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
+            
             public final class App {
                 public static void main(String[] args) {
                     new int[3].toString();
@@ -1396,6 +1504,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public static void main(String[] args) {
@@ -1409,10 +1518,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import java.util.Arrays;
+            
             public final class App {
                 public static void main(String[] args) {
                     Arrays.toString(new int[3]);
@@ -1432,6 +1542,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:ArrayToString")
                 public static void main(String[] args) {
@@ -1445,10 +1556,11 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
 
         then:
         // language=Java
-        appJavaTextEquals '''
+        javaSourceIsSyntacticallyEqualTo '''
             package app;
 
             import java.util.Arrays;
+            
             public final class App {
                 public static void main(String[] args) {
                     Arrays.toString(new int[3]);
@@ -1461,6 +1573,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // language=Java
         writeJavaSourceFileToSourceSets '''
             package app;
+            
             public final class App {
                 @SuppressWarnings("for-rollout:NullAway")
                 public static void method() {
@@ -1533,23 +1646,50 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         super.writeJavaSourceFile(source, 'src/other/java', sourceSetRoot)
     }
 
-    void appJavaTextContains(String substring) {
+    void javaSourceContains(String substring) {
         assert file('app/App.java', mainSourceSet).text.contains(substring)
         assert file('app/App.java', otherSourceSet).text.contains(substring)
     }
 
-    void appJavaTextNotContains(String substring) {
+    void javaSourceDoesNotContain(String substring) {
         assert !file('app/App.java', mainSourceSet).text.contains(substring)
         assert !file('app/App.java', otherSourceSet).text.contains(substring)
     }
 
-    void appJavaTextEquals(String source) {
-        assert file('app/App.java', mainSourceSet).text == source
-        assert file('app/App.java', otherSourceSet).text == source
+    // Normalizes Java source by trimming whitespace and applying consistent formatting.
+    // Preserves newlines since the formatter allows them within methods, and we need
+    // to test that error-prone doesn't introduce unwanted line breaks.
+    private static String normalizeSource(String content) {
+        String stripped = content.readLines()
+                .collect { it.trim() }           // Remove leading/trailing whitespace
+                .join('\n')
+
+        return formatter.formatSource(stripped)
     }
 
-    void appJavaTextNotEquals(String source) {
-        assert file('app/App.java', mainSourceSet).text != source
-        assert file('app/App.java', otherSourceSet).text != source
+    void javaSourceIsSyntacticallyEqualTo(String source) {
+        var output = normalizeSource(file('app/App.java', mainSourceSet).text)
+        var expected = normalizeSource(source)
+
+        // Ensure test fixtures are properly formatted
+        assert "\n" + expected == source, "Please update your text fixtures to be in palantir-java-format"
+        assert output == expected
+
+        var outputOther = normalizeSource(file('app/App.java', otherSourceSet).text)
+        var expectedOther = normalizeSource(source)
+        assert outputOther == expectedOther
+    }
+
+    void javaSourceIsSyntacticallyNotEqualTo(String source) {
+        var output = normalizeSource(file('app/App.java', mainSourceSet).text)
+        var expected = normalizeSource(source)
+
+        // Ensure test fixtures are properly formatted
+        assert "\n" + expected == source, "Please update your text fixtures to be in palantir-java-format"
+        assert output != expected
+
+        var outputOther = normalizeSource(file('app/App.java', otherSourceSet).text)
+        var expectedOther = normalizeSource(source)
+        assert outputOther != expectedOther
     }
 }

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -40,7 +40,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
     //   5. Run the tests as well
     // If the variable below is true the tests will fail as the compilation process will try to
     // attach to a non-existent debugger. Set it to false before you push any code.
-    boolean debuggingErrorPrones = false
+    boolean debuggingErrorPrones = isJwdpLoaded()
 
     def setupSpec() {
         FileUtils.deleteDirectory(nebulatestSourceSets)
@@ -112,7 +112,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                     it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
                         @Override
                         public Iterable<String> asArguments() {
-                            return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005")
+                            return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5006")
                         }
                     })
                 }
@@ -1205,6 +1205,55 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
             }
         '''.stripIndent(true)
     }
+
+    def 'can patch checks while using -PerrorProneRemoveRollout, which also add annotations as fixes'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+
+            public final class App {
+                @SuppressWarnings("for-rollout:ShouldBeNullable")
+                private Object fixme() {
+                    return null;
+                }
+
+                @SuppressWarnings("for-rollout:ShouldBeNullable")       
+                private Object fixme(Object andMySuppressionHasWhiteSpaceAfterIt) {
+                    return null;
+                }
+                
+                @SuppressWarnings({"for-rollout:ShouldBePrivate", "for-rollout:ShouldBeNullable"})
+                Integer fixme(Integer i) {
+                    return null;
+                }
+            }
+        '''.stripIndent(true)
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveRollout=ShouldBeNullable,ShouldBePrivate', '-PerrorProneApply=ShouldBeNullable,ShouldBePrivate')
+
+        then:
+        // language=Java
+        appJavaTextEquals '''
+            package app;
+
+            import javax.annotation.Nullable;
+
+            public final class App {
+                @Nullable private Object fixme() {
+                    return null;
+                }
+
+                @Nullable private Object fixme(Object andMySuppressionHasWhiteSpaceAfterIt) {
+                    return null;
+                }
+                
+                @Nullable private Integer fixme(Integer i) {
+                    return null;
+                }
+            }
+        '''.stripIndent(true)
+    }
+
 
     def 'does not patch checks while using -PerrorProneRemoveRollout, if suppressed normally'() {
         // language=Java

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1668,28 +1668,28 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
     }
 
     void javaSourceIsSyntacticallyEqualTo(String source) {
-        var output = normalizeSource(file('app/App.java', mainSourceSet).text)
-        var expected = normalizeSource(source)
+        def output = normalizeSource(file('app/App.java', mainSourceSet).text)
+        def expected = normalizeSource(source)
 
         // Ensure test fixtures are properly formatted
         assert "\n" + expected == source, "Please update your text fixtures to be in palantir-java-format"
         assert output == expected
 
-        var outputOther = normalizeSource(file('app/App.java', otherSourceSet).text)
-        var expectedOther = normalizeSource(source)
+        def outputOther = normalizeSource(file('app/App.java', otherSourceSet).text)
+        def expectedOther = normalizeSource(source)
         assert outputOther == expectedOther
     }
 
     void javaSourceIsSyntacticallyNotEqualTo(String source) {
-        var output = normalizeSource(file('app/App.java', mainSourceSet).text)
-        var expected = normalizeSource(source)
+        def output = normalizeSource(file('app/App.java', mainSourceSet).text)
+        def expected = normalizeSource(source)
 
         // Ensure test fixtures are properly formatted
         assert "\n" + expected == source, "Please update your text fixtures to be in palantir-java-format"
         assert output != expected
 
-        var outputOther = normalizeSource(file('app/App.java', otherSourceSet).text)
-        var expectedOther = normalizeSource(source)
+        def outputOther = normalizeSource(file('app/App.java', otherSourceSet).text)
+        def expectedOther = normalizeSource(source)
         assert outputOther != expectedOther
     }
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -136,10 +136,13 @@ public final class RemoveRolloutSuppressions extends BugChecker implements BugCh
 
         @Override
         public ImmutableSet<Replacement> getReplacements(EndPosTable endPositions) {
-            // If we are looking to delete the entire element, we should also remove whitespace before it,
-            //   up to and including the newline
             if (replacementText.isEmpty() && sourceCode != null) {
-                int end = SourceCodeUtils.removeUntil(sourceCode, position.getEndPosition(endPositions));
+                // If the next element is in a newline, remove the newline as well.
+                // Ideally, we also remove whitespace before the next element, but that would overlap with any done on
+                // the next element. We leave those spaces to the formatter.
+                // Otherwise, the next element is a non-whitespace. Remove up until the first non-whitespace.
+                int end = SourceCodeUtils.firstNonWhitespaceOrNextLineStart(
+                        sourceCode, position.getEndPosition(endPositions));
                 return ImmutableSet.of(Replacement.create(position.getStartPosition(), end, ""));
             }
             return ImmutableSet.of(Replacement.create(

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -139,9 +139,8 @@ public final class RemoveRolloutSuppressions extends BugChecker implements BugCh
             // If we are looking to delete the entire element, we should also remove whitespace before it,
             //   up to and including the newline
             if (replacementText.isEmpty() && sourceCode != null) {
-                int start = SourceCodeUtils.startPositionWithWhitespaceIncludingNewLine(
-                        sourceCode, position.getStartPosition());
-                return ImmutableSet.of(Replacement.create(start, position.getEndPosition(endPositions), ""));
+                int end = SourceCodeUtils.startOfNextElement(sourceCode, position.getEndPosition(endPositions));
+                return ImmutableSet.of(Replacement.create(position.getStartPosition(), end, ""));
             }
             return ImmutableSet.of(Replacement.create(
                     position.getStartPosition(), position.getEndPosition(endPositions), replacementText));

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -139,7 +139,7 @@ public final class RemoveRolloutSuppressions extends BugChecker implements BugCh
             // If we are looking to delete the entire element, we should also remove whitespace before it,
             //   up to and including the newline
             if (replacementText.isEmpty() && sourceCode != null) {
-                int end = SourceCodeUtils.startOfNextElement(sourceCode, position.getEndPosition(endPositions));
+                int end = SourceCodeUtils.removeUntil(sourceCode, position.getEndPosition(endPositions));
                 return ImmutableSet.of(Replacement.create(position.getStartPosition(), end, ""));
             }
             return ImmutableSet.of(Replacement.create(

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
@@ -63,8 +63,8 @@ final class SourceCodeUtils {
         return pos + 1;
     }
 
-    static int startOfNextElement(CharSequence sourceCode, int endOfThisElement) {
-        int pos = endOfThisElement + 1;
+    static int removeUntil(CharSequence sourceCode, int endOfSuppression) {
+        int pos = endOfSuppression;
 
         for (; pos < sourceCode.length(); pos++) {
             char character = sourceCode.charAt(pos);
@@ -74,23 +74,14 @@ final class SourceCodeUtils {
         }
 
         if (pos < sourceCode.length() && sourceCode.charAt(pos) == '\n') {
-            // If the next element is in a newline, remove whitespace before the next element as well
-            return firstNonWhitespace(sourceCode, pos + 1);
+            // If the next element is in a newline, remove the newline as well.
+            // Ideally, we also remove whitespace before the next element, but that would overlap with any done on the
+            // next element. We leave those spaces to the formatter.
+            return pos + 1;
         } else {
             // Otherwise, the next element is on the same line.
             return pos;
         }
-    }
-
-    private static int firstNonWhitespace(CharSequence sourceCode, int start) {
-        int pos = start;
-        for (; pos < sourceCode.length(); pos++) {
-            char character = sourceCode.charAt(pos);
-            if (character == '\n' || !Character.isWhitespace(character)) {
-                break;
-            }
-        }
-        return pos;
     }
 
     private SourceCodeUtils() {}

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
@@ -63,5 +63,35 @@ final class SourceCodeUtils {
         return pos + 1;
     }
 
+    static int startOfNextElement(CharSequence sourceCode, int endOfThisElement) {
+        int pos = endOfThisElement + 1;
+
+        for (; pos < sourceCode.length(); pos++) {
+            char character = sourceCode.charAt(pos);
+            if (character == '\n' || !Character.isWhitespace(character)) {
+                break;
+            }
+        }
+
+        if (pos < sourceCode.length() && sourceCode.charAt(pos) == '\n') {
+            // If the next element is in a newline, remove whitespace before the next element as well
+            return firstNonWhitespace(sourceCode, pos + 1);
+        } else {
+            // Otherwise, the next element is on the same line.
+            return pos;
+        }
+    }
+
+    private static int firstNonWhitespace(CharSequence sourceCode, int start) {
+        int pos = start;
+        for (; pos < sourceCode.length(); pos++) {
+            char character = sourceCode.charAt(pos);
+            if (character == '\n' || !Character.isWhitespace(character)) {
+                break;
+            }
+        }
+        return pos;
+    }
+
     private SourceCodeUtils() {}
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SourceCodeUtils.java
@@ -63,25 +63,19 @@ final class SourceCodeUtils {
         return pos + 1;
     }
 
-    static int removeUntil(CharSequence sourceCode, int endOfSuppression) {
-        int pos = endOfSuppression;
+    static int firstNonWhitespaceOrNextLineStart(CharSequence sourceCode, int startPosition) {
+        int pos = startPosition;
 
         for (; pos < sourceCode.length(); pos++) {
             char character = sourceCode.charAt(pos);
-            if (character == '\n' || !Character.isWhitespace(character)) {
-                break;
+            if (character == '\n') {
+                return Math.min(pos + 1, sourceCode.length());
+            } else if (!Character.isWhitespace(character)) {
+                return pos;
             }
         }
 
-        if (pos < sourceCode.length() && sourceCode.charAt(pos) == '\n') {
-            // If the next element is in a newline, remove the newline as well.
-            // Ideally, we also remove whitespace before the next element, but that would overlap with any done on the
-            // next element. We leave those spaces to the formatter.
-            return pos + 1;
-        } else {
-            // Otherwise, the next element is on the same line.
-            return pos;
-        }
+        return pos;
     }
 
     private SourceCodeUtils() {}

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -85,19 +85,19 @@ class WhitespaceIndentBeforeTest {
     }
 
     @Nested
-    class RemoveUntil {
+    class FirstNonWhitespaceOrNextLineStart {
         @Test
         void next_element_on_same_line() {
-            assertThat(removeUntil("class| Foo")).isEqualTo(6);
+            assertThat(firstNonWhitespaceOrNextLineStart("class| Foo")).isEqualTo(6);
         }
 
         @Test
         void next_element_in_newline() {
-            assertThat(removeUntil("class| \n   Foo")).isEqualTo(7);
+            assertThat(firstNonWhitespaceOrNextLineStart("class| \n   Foo")).isEqualTo(7);
         }
 
-        private static int removeUntil(String testCase) {
-            return SourceCodeUtils.removeUntil(testCase.replace("|", ""), testCase.indexOf('|'));
+        private static int firstNonWhitespaceOrNextLineStart(String testCase) {
+            return SourceCodeUtils.firstNonWhitespaceOrNextLineStart(testCase.replace("|", ""), testCase.indexOf('|'));
         }
     }
 }

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -83,4 +83,21 @@ class WhitespaceIndentBeforeTest {
                     testCase.replace("|", ""), testCase.indexOf('|'));
         }
     }
+
+    @Nested
+    class StartOfNextElement {
+        @Test
+        void next_element_on_same_line() {
+            assertThat(startOfNextElement("class| Foo")).isEqualTo(6);
+        }
+
+        @Test
+        void next_element_in_newline() {
+            assertThat(startOfNextElement("class|  \n   Foo")).isEqualTo(11);
+        }
+
+        private static int startOfNextElement(String testCase) {
+            return SourceCodeUtils.startOfNextElement(testCase.replace("|", ""), testCase.indexOf('|'));
+        }
+    }
 }

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/WhitespaceIndentBeforeTest.java
@@ -85,19 +85,19 @@ class WhitespaceIndentBeforeTest {
     }
 
     @Nested
-    class StartOfNextElement {
+    class RemoveUntil {
         @Test
         void next_element_on_same_line() {
-            assertThat(startOfNextElement("class| Foo")).isEqualTo(6);
+            assertThat(removeUntil("class| Foo")).isEqualTo(6);
         }
 
         @Test
         void next_element_in_newline() {
-            assertThat(startOfNextElement("class|  \n   Foo")).isEqualTo(11);
+            assertThat(removeUntil("class| \n   Foo")).isEqualTo(7);
         }
 
-        private static int startOfNextElement(String testCase) {
-            return SourceCodeUtils.startOfNextElement(testCase.replace("|", ""), testCase.indexOf('|'));
+        private static int removeUntil(String testCase) {
+            return SourceCodeUtils.removeUntil(testCase.replace("|", ""), testCase.indexOf('|'));
         }
     }
 }

--- a/test-error-prone-checks/src/main/java/com/palantir/gradle/suppressibleerrorprone/ShouldBeNullable.java
+++ b/test-error-prone-checks/src/main/java/com/palantir/gradle/suppressibleerrorprone/ShouldBeNullable.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.suppressibleerrorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.MethodTree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "This check is meant only for testing suppressible-error-prone functionality")
+public final class ShouldBeNullable extends BugChecker implements BugChecker.MethodTreeMatcher {
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        if (tree.getName().contentEquals("fixme")) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            String qualifiedAnnotation = SuggestedFixes.qualifyType(state, fix, "javax.annotation.Nullable");
+            fix.prefixWith(tree, String.format("@%s ", qualifiedAnnotation));
+            return buildDescription(tree).addFix(fix.build()).build();
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/test-error-prone-checks/src/main/java/com/palantir/gradle/suppressibleerrorprone/ShouldBePrivate.java
+++ b/test-error-prone-checks/src/main/java/com/palantir/gradle/suppressibleerrorprone/ShouldBePrivate.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.suppressibleerrorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.MethodTree;
+import javax.lang.model.element.Modifier;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "This check is meant only for testing suppressible-error-prone functionality")
+public final class ShouldBePrivate extends BugChecker implements BugChecker.MethodTreeMatcher {
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        if (tree.getName().contentEquals("fixme")
+                && !tree.getModifiers().getFlags().contains(Modifier.PRIVATE)) {
+            SuggestedFix fix =
+                    SuggestedFixes.addModifiers(tree, state, Modifier.PRIVATE).orElseGet(SuggestedFix::emptyFix);
+            return buildDescription(tree).addFix(fix).build();
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/versions.lock
+++ b/versions.lock
@@ -20,7 +20,7 @@ com.google.errorprone:error_prone_check_api:2.41.0 (2 constraints: ca195cd6)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
-com.google.guava:guava:33.5.0-jre (9 constraints: d7948055)
+com.google.guava:guava:33.5.0-jre (12 constraints: 04d77c1e)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
@@ -50,7 +50,21 @@ org.ow2.asm:asm:9.9 (2 constraints: be0e7759)
 
 cglib:cglib-nodep:3.2.2 (1 constraints: 490ded24)
 
+com.fasterxml.jackson.core:jackson-annotations:2.19.2 (3 constraints: bd3ddca3)
+
+com.fasterxml.jackson.core:jackson-core:2.19.2 (5 constraints: 2f6b3a28)
+
+com.fasterxml.jackson.core:jackson-databind:2.19.2 (4 constraints: a2584b0d)
+
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.19.2 (1 constraints: 8a142d90)
+
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.19.2 (1 constraints: 11132d39)
+
+com.fasterxml.jackson.module:jackson-module-parameter-names:2.19.2 (1 constraints: 11132d39)
+
 com.google.auto.value:auto-value:1.10 (1 constraints: e711f8e8)
+
+com.google.code.findbugs:jsr305:3.0.2 (1 constraints: d8120c26)
 
 com.google.errorprone:error_prone_test_helpers:2.41.0 (1 constraints: 3e054c3b)
 
@@ -68,6 +82,10 @@ com.palantir.gradle.plugintesting:configuration-cache-spec:0.12.0 (1 constraints
 
 com.palantir.gradle.plugintesting:plugin-testing-core:0.12.0 (1 constraints: 3505293b)
 
+com.palantir.javaformat:palantir-java-format:2.75.0 (1 constraints: 4005563b)
+
+com.palantir.javaformat:palantir-java-format-spi:2.75.0 (1 constraints: 11133739)
+
 commons-io:commons-io:2.20.0 (1 constraints: 3605333b)
 
 junit:junit:4.13.2 (4 constraints: 873fce86)
@@ -79,6 +97,8 @@ org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
 org.assertj:assertj-core:3.27.6 (1 constraints: 4405543b)
 
 org.codehaus.groovy:groovy:3.0.25 (3 constraints: 14347add)
+
+org.functionaljava:functionaljava:4.8 (1 constraints: 81129900)
 
 org.hamcrest:hamcrest:2.2 (2 constraints: 43187376)
 

--- a/versions.props
+++ b/versions.props
@@ -3,6 +3,7 @@ com.google.guava:guava = 33.5.0-jre
 com.netflix.nebula:nebula-test = 10.6.2
 com.palantir.gradle.utils:environment-variables = 0.19.0
 com.palantir.gradle.plugintesting:* = 0.11.0
+com.palantir.javaformat:* = 2.75.0
 commons-io:commons-io = 2.20.0
 net.ltgt.gradle:gradle-errorprone-plugin = 4.3.0
 org.assertj:assertj-core = 3.27.6


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Resolves https://github.com/palantir/suppressible-error-prone/pull/70. 

Our whitespace formatting in RemoveRollout's LineRemovingReplacementFix was overlapping with other fixes, causing LineRemovingReplacementFix to be dropped. 

## After this PR

- Instead of removing whitespace and newlines by expanding the start of the fix, we do it by expanding the end of the fix. RemoveRollout now isn't dropped when there is a fix on the same AnnotationTree. 
- Use the formatter in our integration tests so tests still can pass. This is okay as suppressible-error-prone is always run with the formatter both in local and in excavators anyways

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix apply + remove rollout overlapping with one another
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

