### PR TITLE
Fix publication due to bad subproject setup

### DIFF
--- a/test-error-prone-checks/build.gradle
+++ b/test-error-prone-checks/build.gradle
@@ -18,3 +18,7 @@ publishing {
         }
     }
 }
+
+tasks.withType(PublishToMavenRepository) {
+    onlyIf { repo -> repo.repository.name == 'MavenLocal' }
+}

--- a/test-error-prone-checks/build.gradle
+++ b/test-error-prone-checks/build.gradle
@@ -19,6 +19,6 @@ publishing {
     }
 }
 
-tasks.withType(PublishToMavenRepository) {
+tasks.withType(PublishToMavenRepository).configureEach {
     onlyIf { repo -> repo.repository.name == 'MavenLocal' }
 }


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/suppressible-error-prone/pull/160 added a new subproject for tests, which we want to publish only to mavenLocal.

Unfortunately, this [broke publication](https://app.circleci.com/pipelines/github/palantir/suppressible-error-prone/768/workflows/6bd9c184-3934-442b-b8ec-c0290bcd00e5/jobs/1572) because it was actually trying to publish to sonatype but wasn't properly wired up (most likely because https://github.com/palantir/gradle-external-publish-plugin sets up the sonatype repository automatically). 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix publication due to bad subproject setup
==COMMIT_MSG==

## Possible downsides?
I've not actually sure this will fix publication, but it at least doesn't seem to break tests. I'm not sure how to tests apart from trying to merge this.

