### PR TITLE
Create the `JdwpRemoteDebugPlugin` and the `Debug errorprones` Intellij debug config, to make debugging error-prones easier

### DIFF
--- a/.idea/runConfigurations/Debug_errorprones.xml
+++ b/.idea/runConfigurations/Debug_errorprones.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Debug errorprones" type="Remote">
+        <option name="USE_SOCKET_TRANSPORT" value="true" />
+        <option name="SERVER_MODE" value="true" />
+        <option name="SHMEM_ADDRESS" />
+        <option name="HOST" value="localhost" />
+        <option name="PORT" value="5006" />
+        <option name="AUTO_RESTART" value="true" />
+        <RunnerSettings RunnerId="Debug">
+            <option name="DEBUG_PORT" value="5006" />
+            <option name="LOCAL" value="false" />
+        </RunnerSettings>
+        <method v="2" />
+    </configuration>
+</component>

--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -33,11 +33,11 @@ gradlePlugin {
             implementationClass = 'com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin'
         }
         jdwpRemoteDebugPlugin {
-            id = 'com.palantir.jdwp-remote-debug'
+            id = 'com.palantir.remote-debug-java-compile'
             displayName = 'JDWP Remote Debug Plugin'
             description = 'Configures Java compilation tasks to connect to a remote JDWP debugger for debugging ErrorProne and other compiler processes.'
             tags = ['jdwp', 'remote-debug', 'java', 'debugging', 'compiler']
-            implementationClass = 'com.palantir.gradle.suppressibleerrorprone.JdwpRemoteDebugPlugin'
+            implementationClass = 'com.palantir.gradle.suppressibleerrorprone.RemoteDebugJavaCompilePlugin'
         }
     }
 }

--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -32,6 +32,13 @@ gradlePlugin {
             tags = ['error-prone', 'javac', 'suppression']
             implementationClass = 'com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin'
         }
+        jdwpRemoteDebugPlugin {
+            id = 'com.palantir.jdwp-remote-debug'
+            displayName = 'JDWP Remote Debug Plugin'
+            description = 'Configures Java compilation tasks to connect to a remote JDWP debugger for debugging ErrorProne and other compiler processes.'
+            tags = ['jdwp', 'remote-debug', 'java', 'debugging', 'compiler']
+            implementationClass = 'com.palantir.gradle.suppressibleerrorprone.JdwpRemoteDebugPlugin'
+        }
     }
 }
 

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
@@ -24,10 +24,9 @@ import org.gradle.process.CommandLineArgumentProvider;
 
 /**
  * To debug suppressible-error-prone in a build (works with breakpoints in VisitorStateModifications):
- * 1. Apply this plugin to the build
- * 2. Run the "Debug errorprones" debug config which ships with this repository. Notably, it sets up a jdwp listener
+ * 1. Run the "Debug errorprones" debug config which ships with this repository. Notably, it sets up a jdwp listener
  *    at port 5006
- * 3. Run the build
+ * 2. Run the build with this plugin applied
  */
 public abstract class JdwpRemoteDebugPlugin implements Plugin<Project> {
     // No other way to programmatically check whether the configuration-cache is on

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
@@ -25,8 +25,8 @@ import org.gradle.process.CommandLineArgumentProvider;
 /**
  * To debug suppressible-error-prone in a build (works with breakpoints in VisitorStateModifications):
  * 1. Run the "Debug errorprones" debug config which ships with this repository. Notably, it sets up a jdwp listener
- *    at port 5006
- * 2. Run the build with this plugin applied
+ *    on port 5006
+ * 2. Run the build-under-test with this plugin applied
  */
 public abstract class JdwpRemoteDebugPlugin implements Plugin<Project> {
     @Inject

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
@@ -17,8 +17,10 @@
 package com.palantir.gradle.suppressibleerrorprone;
 
 import java.util.List;
+import javax.inject.Inject;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.configuration.BuildFeatures;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.process.CommandLineArgumentProvider;
 

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.suppressibleerrorprone;
+
+import java.util.List;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.process.CommandLineArgumentProvider;
+
+/**
+ * To debug suppressible-error-prone in a build (works with breakpoints in VisitorStateModifications):
+ * 1. Apply this plugin to the build
+ * 2. Run the "Debug errorprones" debug config which ships with this repository. Notably, it sets up a jdwp listener
+ *    at port 5006
+ * 3. Run the build
+ */
+public abstract class JdwpRemoteDebugPlugin implements Plugin<Project> {
+    // No other way to programmatically check whether the configuration-cache is on
+    @SuppressWarnings("DeprecatedApiUsage")
+    @Override
+    public final void apply(Project project) {
+
+        if (project.getGradle().getStartParameter().isConfigurationCacheRequested()) {
+            throw new IllegalArgumentException(
+                    "The JDWP will throw a cryptic error when run with the configuration cache. Turn off configuration"
+                            + " cache for the build-under-debug. Hint: you can conditionally apply "
+                            + "`com.palantir.jdwp-remote-debug` only if `IntegrationTestKitBase#isJdwpLoaded()`");
+        }
+
+        project.getPluginManager().withPlugin("java", unused -> {
+            project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
+                javaCompile
+                        .getOptions()
+                        .getForkOptions()
+                        .getJvmArgumentProviders()
+                        .add(new CommandLineArgumentProvider() {
+                            @Override
+                            public Iterable<String> asArguments() {
+                                return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5006");
+                            }
+                        });
+            });
+        });
+    }
+}

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/JdwpRemoteDebugPlugin.java
@@ -29,12 +29,12 @@ import org.gradle.process.CommandLineArgumentProvider;
  * 2. Run the build with this plugin applied
  */
 public abstract class JdwpRemoteDebugPlugin implements Plugin<Project> {
-    // No other way to programmatically check whether the configuration-cache is on
-    @SuppressWarnings("DeprecatedApiUsage")
+    @Inject
+    protected abstract BuildFeatures getBuildFeatures();
+
     @Override
     public final void apply(Project project) {
-
-        if (project.getGradle().getStartParameter().isConfigurationCacheRequested()) {
+        if (getBuildFeatures().getConfigurationCache().getActive().get()) {
             throw new IllegalArgumentException(
                     "The JDWP will throw a cryptic error when run with the configuration cache. Turn off configuration"
                             + " cache for the build-under-debug. Hint: you can conditionally apply "

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/RemoteDebugJavaCompilePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/RemoteDebugJavaCompilePlugin.java
@@ -40,7 +40,8 @@ public abstract class RemoteDebugJavaCompilePlugin implements Plugin<Project> {
             throw new IllegalArgumentException(
                     "The JDWP will throw a cryptic error when run with the configuration cache. Turn off configuration"
                             + " cache for the build-under-debug. Hint: you can conditionally apply "
-                            + "`com.palantir.remote-debug-java-compile` only if `IntegrationTestKitBase#isJdwpLoaded()`");
+                            + "`com.palantir.remote-debug-java-compile` only if "
+                            + "`IntegrationTestKitBase#isJdwpLoaded()`");
         }
 
         project.getPluginManager().withPlugin("java", unused -> {

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/RemoteDebugJavaCompilePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/RemoteDebugJavaCompilePlugin.java
@@ -30,7 +30,7 @@ import org.gradle.process.CommandLineArgumentProvider;
  *    on port 5006
  * 2. Run the build-under-test with this plugin applied
  */
-public abstract class JdwpRemoteDebugPlugin implements Plugin<Project> {
+public abstract class RemoteDebugJavaCompilePlugin implements Plugin<Project> {
     @Inject
     protected abstract BuildFeatures getBuildFeatures();
 
@@ -40,7 +40,7 @@ public abstract class JdwpRemoteDebugPlugin implements Plugin<Project> {
             throw new IllegalArgumentException(
                     "The JDWP will throw a cryptic error when run with the configuration cache. Turn off configuration"
                             + " cache for the build-under-debug. Hint: you can conditionally apply "
-                            + "`com.palantir.jdwp-remote-debug` only if `IntegrationTestKitBase#isJdwpLoaded()`");
+                            + "`com.palantir.remote-debug-java-compile` only if `IntegrationTestKitBase#isJdwpLoaded()`");
         }
 
         project.getPluginManager().withPlugin("java", unused -> {

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -39,6 +39,9 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         // To debug the tests in this file
         // 1. Run the "Debug errorprones" debug configuration, which ships with this repository
         // 2. Go to the test you're looking for and run debug on it as well, but without any special configurations
+
+        // An implementation detail: this is already set in IntegrationTestKitSpec, but only at runner creation time,
+        // which is too late! We set it early here
         debug = isJwdpLoaded()
         sourceSetRoot = new File(nebulatestSourceSets, projectDir.name)
         mainSourceSet = directory('src/main/java', sourceSetRoot)

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -100,7 +100,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         if (debug) {
             // language=Gradle
             buildFile << '''
-                apply plugin: 'com.palantir.jdwp-remote-debug'
+                apply plugin: 'com.palantir.remote-debug-java-compile'
             '''.stripIndent(true)
         }
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -30,23 +30,16 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
     File mainSourceSet
     File otherSourceSet
 
-    // This makes debugging the errorprone check code running inside the compiler (including the bytecode
-    // edited modifications we have made) "just work" from inside these tests.
-    // Change the variable below to true to enable it, after setting up the standalone debugger:
-    //   1. Make a new run configuration in IntelliJ of type JVM Debug
-    //   2. Change it to "Listen" rather than "Attach"
-    //   3. Select Auto-restart.
-    //   4. Run the debugger
-    //   5. Run the tests as well
-    // If the variable below is true the tests will fail as the compilation process will try to
-    // attach to a non-existent debugger. Set it to false before you push any code.
-    boolean debuggingErrorPrones = false
 
     def setupSpec() {
         FileUtils.deleteDirectory(nebulatestSourceSets)
     }
 
     def setup() {
+        // To debug the tests in this file
+        // 1. Run the "Debug errorprones" debug configuration, which ships with this repository
+        // 2. Go to the test you're looking for and run debug on it as well, but without any special configurations
+        debug = isJwdpLoaded()
         sourceSetRoot = new File(nebulatestSourceSets, projectDir.name)
         mainSourceSet = directory('src/main/java', sourceSetRoot)
         otherSourceSet = directory('src/other/java', sourceSetRoot)
@@ -101,17 +94,10 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
             sourceSets.other.java.srcDirs('${projectDir.relativePath(otherSourceSet)}')
         """.stripIndent(true)
 
-        if (debuggingErrorPrones) {
+        if (debug) {
             // language=Gradle
             buildFile << '''
-                tasks.withType(JavaCompile).configureEach {
-                    it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
-                        @Override
-                        public Iterable<String> asArguments() {
-                            return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005")
-                        }
-                    })
-                }
+                apply plugin: 'com.palantir.jdwp-remote-debug'
             '''.stripIndent(true)
         }
 
@@ -1348,7 +1334,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
     BuildResult runTasksSuccessfully(String... tasks) {
         def projectVersion = Optional.ofNullable(System.getProperty('projectVersion')).orElseThrow()
         String[] strings = tasks + ["-PsuppressibleErrorProneVersion=${projectVersion}".toString()]
-        if (debuggingErrorPrones) {
+        if (debug) {
             return super.runTasks(strings)
         } else {
             return super.runTasksWithConfigurationCache(strings)
@@ -1358,7 +1344,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
     BuildResult runTasksWithFailure(String... tasks) {
         def projectVersion = Optional.ofNullable(System.getProperty('projectVersion')).orElseThrow()
         String[] strings = tasks + ["-PsuppressibleErrorProneVersion=${projectVersion}".toString()]
-        if (debuggingErrorPrones) {
+        if (debug) {
             return super.runTasksAndFail(strings)
         } else {
             return super.runTasksAndFailWithConfigurationCache(strings)

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,13 @@ suppressibleErrorProne {
 }
 ```
 
+### Debugging
+
+If you're a library which ships BugCheckers, you have written `IntegrationTestKitSpec`s to test them, you can debug the error-prones as follows:
+
+1. Run the `Debug errorprones` debug configuration which ships with this repository. This configuration listens for debug events on port 5006. You may copy `Debug_errorprones.xml` from this repository and `git add --force` to your own repository.
+2. Run the build-under-test with the `RemoteDebugJavaCompilePlugin` applied, which ships with `gradle-suppressible-error-prone` and configures your build-under-test to emit debugging events on port 5006. See [this example](https://github.com/palantir/suppressible-error-prone/blob/02b8f54215397f7226f6ea052fe6023b65244212/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy#L100).
+
 ### How do we intercept all the errorprone errors?
 
 We actually modify the core errorprone library to achieve this using a Gradle [Artifact Transform](https://docs.gradle.org/8.10.2/userguide/artifact_transforms.html). This allows us to minimally rewrite the bytecode in the jar that has [`VisitorState#reportMatch`](https://github.com/google/error-prone/blob/f0c3c1eb1b576ee9bc44f1f21c9379e7a02dd745/check_api/src/main/java/com/google/errorprone/VisitorState.java#L281) method and add a call to our own static method to modify the `description` as a first step and add our own fix for `@RepeatableSuppressWarnings`.


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

In this repo, and every repo which consumes suppressible-error-prone, to debug errorprones, we have to 

1. Create a Remote JVM Debug config following some instructions
2. Add the snippet below to the build-under-test
3. Run the debug config
4. Run the test

```java
tasks.withType(JavaCompile).configureEach {
    it.options.forkOptions.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
        @Override
        public Iterable<String> asArguments() {
            return List.of("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5006")
        }
    })
}
```


## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Simplify step 1 by creating a debug config file, which can also be replicated to other repositories like gradle-baseline

Also, simplify step 2 by exporting a gradle plugin which does the above for you.

==COMMIT_MSG==
Create the `JdwpRemoteDebugPlugin` and the `Debug errorprones` Intellij debug config, to make debugging error-prones easier
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Removing step 1 would be a game changer. I tried to do this with a [compound task](https://www.jetbrains.com/help/idea/run-debug-multiple.html) which ran both the jdwp listener and the test build, but there was no way to run a compound task which runs a specific test case, like how intellij allows you to run test cases from the gutter. 



