### PR TITLE
Create a `LazySuppressionFix` to allow for lazily adding/removing suppressions

### DIFF
--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1173,8 +1173,13 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         writeJavaSourceFileToSourceSets '''
             package app;
             
+            // We can remove entire lines
             @SuppressWarnings("for-rollout:Test")
-            public final class App {}
+            public final class App {
+                // We keep non-rollout suppressions untouched
+                @SuppressWarnings({"for-rollout:Test", "Test"})
+                void nested() {}
+            }
         '''.stripIndent(true)
 
         when:
@@ -1185,7 +1190,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         javaSourceIsSyntacticallyEqualTo '''
             package app;
             
-            public final class App {}
+            // We can remove entire lines
+            public final class App {
+                // We keep non-rollout suppressions untouched
+                @SuppressWarnings("Test")
+                void nested() {}
+            }
         '''.stripIndent(true)
     }
 

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -694,6 +694,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                     new int[3].toString();
                     new int[3].equals(new int[3]);
                 }
+                
+                // Does not remove existing suppressions
+                @SuppressWarnings("checkstyle:LineLength")
+                public static void helper() {
+                    new int[3].equals(new int[3]);
+                }
             }
         '''.stripIndent(true)
 
@@ -711,6 +717,12 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                 @SuppressWarnings("for-rollout:ArrayEquals")
                 public static void main(String[] args) {
                     Arrays.toString(new int[3]);
+                    new int[3].equals(new int[3]);
+                }
+                                
+                // Does not remove existing suppressions
+                @SuppressWarnings({"checkstyle:LineLength", "for-rollout:ArrayEquals"})
+                public static void helper() {
                     new int[3].equals(new int[3]);
                 }
             }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionFix.java
@@ -27,17 +27,16 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
- * A Fix that can lazily add/modify/remove @SuppressWarnings annotations with proper line handling.
- * When removing suppressions entirely, it will also remove preceding whitespace up to and including
- * the newline to avoid leaving empty lines.
- * Sorts suppressions by human-authored first, then alphabetically.
+ * A Fix which contains the desired end state of the {@code @SuppressWarnings} annotation on a suppressible. Supports
+ * lazily adding/removing suppressions. If no suppressions are present at render time, it will remove the
+ * {@code @SuppressWarnings} annotation, along with the newline. Suppressions in the rendered fix are sorted by
+ * human-authored first, then alphabetically.
  */
 final class LazySuppressionFix implements Fix {
     private final Set<String> desiredSuppressions = new HashSet<>();
-    private final Function<EndPosTable, ImmutableSet<Replacement>> replacement;
+    private final FirstTimeMemoizingFunction<EndPosTable, ImmutableSet<Replacement>> replacement;
 
     private LazySuppressionFix(
             Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppression, Tree declaration) {

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionFix.java
@@ -29,26 +29,40 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-final class SuppressingFix implements Fix {
-    private final Set<String> newSuppressions = new HashSet<>();
+/**
+ * A Fix that can lazily add/modify/remove @SuppressWarnings annotations with proper line handling.
+ * When removing suppressions entirely, it will also remove preceding whitespace up to and including
+ * the newline to avoid leaving empty lines.
+ * Sorts suppressions by human-authored first, then alphabetically.
+ */
+final class LazySuppressionFix implements Fix {
+    private final Set<String> desiredSuppressions = new HashSet<>();
     private final Function<EndPosTable, ImmutableSet<Replacement>> replacement;
 
-    SuppressingFix(Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
-        // See note in SuppressingReplacement about when we have to calculate stuff
-        // We *cannot* simply make this a memoized supplier. The first thing error-prone does with the Fix is to
-        // evaluate it to produce a nice error message, and we don't want to fix the number of suppression we make
-        // until we're ready to produce the Replacement after *all* the error-prone checks have been run.
-        // In order for SuppressingReplacement to calculate source code positions elements when it's constructed, it
-        // needs an EndPosTable. However, we don't get the EndPosTable until getReplacements is called. So we have
-        // to use this FirstTimeMemoizingFunction thing, that will allow use to defer creating the Replacement until
-        // we have access to the EndPosTable, then keep hold of the created SuppressingReplacement. We only need a
-        // single instance of EndPosTable to evaluate the source positions exactly once, so this works out.
-        this.replacement = new FirstTimeMemoizingFunction<>((EndPosTable endPositions) -> ImmutableSet.of(
-                new SuppressingReplacement(endPositions, newSuppressions, sourceCode, suppressWarnings, tree)));
+    private LazySuppressionFix(
+            Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppression, Tree declaration) {
+        // Defer replacement creation until we have EndPosTable and all suppressions have been added
+        this.replacement = new FirstTimeMemoizingFunction<>(
+                (EndPosTable endPositions) -> ImmutableSet.of(new LazySuppressionReplacement(
+                        endPositions, desiredSuppressions, sourceCode, suppression, declaration)));
+    }
+
+    LazySuppressionFix(
+            Optional<CharSequence> sourceCode,
+            Optional<? extends AnnotationTree> suppressWarnings,
+            Tree tree,
+            Set<String> desiredSuppressions) {
+        this(sourceCode, suppressWarnings, tree);
+        this.desiredSuppressions.addAll(desiredSuppressions);
+    }
+
+    public static LazySuppressionFix empty(
+            Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppression, Tree tree) {
+        return new LazySuppressionFix(sourceCode, suppression, tree);
     }
 
     public void addSuppression(String suppression) {
-        newSuppressions.add(suppression);
+        desiredSuppressions.add(suppression);
     }
 
     @Override
@@ -58,12 +72,12 @@ final class SuppressingFix implements Fix {
 
     @Override
     public String toString(JCCompilationUnit compilationUnit) {
-        return "SuppressingFix";
+        return "LazySuppressionFix";
     }
 
     @Override
     public String getShortDescription() {
-        return "Adding automatic suppressions";
+        return "Adding/modifying/removing @SuppressWarnings with proper line handling";
     }
 
     @Override

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionFix.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionFix.java
@@ -33,28 +33,50 @@ import java.util.Set;
  * lazily adding/removing suppressions. If no suppressions are present at render time, it will remove the
  * {@code @SuppressWarnings} annotation, along with the newline. Suppressions in the rendered fix are sorted by
  * human-authored first, then alphabetically.
+ *
+ * <p>
+ *
+ * We have to handle line removal ourselves because the normal {@link com.google.errorprone.fixes.SuggestedFix} does not
+ * allow us to introduce a Replacement which has a different start position than the tree's normal start position.
  */
 final class LazySuppressionFix implements Fix {
+    // This set describes the desired end state of the fix. Suppressions can be added and removed from this set until
+    // the LazySuppressingReplacement is rendered
     private final Set<String> desiredSuppressions = new HashSet<>();
     private final FirstTimeMemoizingFunction<EndPosTable, ImmutableSet<Replacement>> replacement;
 
     private LazySuppressionFix(
             Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppression, Tree declaration) {
-        // Defer replacement creation until we have EndPosTable and all suppressions have been added
+        // See note in LazySuppressionReplacement about when we have to calculate stuff
+        // We *cannot* simply make this a memoized supplier. The first thing error-prone does with the Fix is to
+        // evaluate it to produce a nice error message, and we don't want to fix the number of suppression we make
+        // until we're ready to produce the Replacement after *all* the error-prone checks have been run.
+        // In order for SuppressingReplacement to calculate source code positions elements when it's constructed, it
+        // needs an EndPosTable. However, we don't get the EndPosTable until getReplacements is called. So we have
+        // to use this FirstTimeMemoizingFunction thing, that will allow use to defer creating the Replacement until
+        // we have access to the EndPosTable, then keep hold of the created SuppressingReplacement. We only need a
+        // single instance of EndPosTable to evaluate the source positions exactly once, so this works out.
         this.replacement = new FirstTimeMemoizingFunction<>(
                 (EndPosTable endPositions) -> ImmutableSet.of(new LazySuppressionReplacement(
                         endPositions, desiredSuppressions, sourceCode, suppression, declaration)));
     }
 
+    /**
+     * Initialize a {@code LazySuppressingFix} on {@code suppressWarnings} with the initial suppressions
+     * {@code desiredSuppressions}.
+     */
     LazySuppressionFix(
             Optional<CharSequence> sourceCode,
             Optional<? extends AnnotationTree> suppressWarnings,
-            Tree tree,
+            Tree declaration,
             Set<String> desiredSuppressions) {
-        this(sourceCode, suppressWarnings, tree);
+        this(sourceCode, suppressWarnings, declaration);
         this.desiredSuppressions.addAll(desiredSuppressions);
     }
 
+    /**
+     * Initialize a {@code LazySuppressingFix} on {@code suppressWarnings} with no suppressions initially.
+     */
     public static LazySuppressionFix empty(
             Optional<CharSequence> sourceCode, Optional<? extends AnnotationTree> suppression, Tree tree) {
         return new LazySuppressionFix(sourceCode, suppression, tree);

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionReplacement.java
@@ -33,6 +33,10 @@ import java.util.stream.Collectors;
  * whitespace up to and including the newline.
  */
 final class LazySuppressionReplacement extends Replacement {
+    // We really do need to be this lazy for generating the Replacements, as error-prone immediately converts
+    // the Fix to a Replacement when a Description is given to it, and we need to defer the computation of the
+    // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
+    // at the same level.
     private final Range<Integer> range;
     private final List<String> existingSuppressions;
     private final String suffix;
@@ -50,7 +54,14 @@ final class LazySuppressionReplacement extends Replacement {
         this.sourceCode = sourceCode;
         this.suppressWarnings = suppressWarnings;
 
-        // Calculate range immediately to avoid tree representation changes
+        // There is an additional issue that by the time error-prone comes around to apply the replacements, the
+        // compiler seems to change the representation of the tree for another phase - `App.Builder` becomes
+        // `App$Builder` etc and the start position for the expression changes to be after `App` rather than at the
+        // start of `App`. If we calculate the replacement range too late, we insert our @SuppressWarnings at the
+        // wrong location, and the indentation is miscalculated. But we can't calculate the replacement string
+        // straight away, as we might not have all the new suppressions added yet. So we have to immediately
+        // calculate the replacement range and indentation/suffix, but hold off building the final replacement
+        // string until we have all the new suppressions.
         this.range = calculateRange(endPositions, suppressWarnings, declaration);
 
         this.suffix = suppressWarnings

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionReplacement.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/LazySuppressionReplacement.java
@@ -27,42 +27,37 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-final class SuppressingReplacement extends Replacement {
-    // We really do need to be this lazy for generating the Replacements, as error-prone immediately converts
-    // the Fix to a Replacement when a Description is given to it, and we need to defer the computation of the
-    // Replacement until a number of Descriptions have been produced, to handle multiple errors being suppressed
-    // at the same level.
-
+/**
+ * A Replacement that handles @SuppressWarnings modifications with line-removing capabilities.
+ * When the final replacement text is empty (no suppressions), it will remove preceding
+ * whitespace up to and including the newline.
+ */
+final class LazySuppressionReplacement extends Replacement {
     private final Range<Integer> range;
     private final List<String> existingSuppressions;
     private final String suffix;
-    private final Set<String> newSuppressions;
+    private final Set<String> desiredSuppressions;
+    private final Optional<CharSequence> sourceCode;
+    private final Optional<? extends AnnotationTree> suppressWarnings;
 
-    SuppressingReplacement(
+    LazySuppressionReplacement(
             EndPosTable endPositions,
-            Set<String> newSuppressions,
+            Set<String> desiredSuppressions,
             Optional<CharSequence> sourceCode,
             Optional<? extends AnnotationTree> suppressWarnings,
-            Tree tree) {
-        // Note this is a *mutable* set from SuppressingFix, we need to able to add a new suppression before this
-        // instance is instantiated
-        this.newSuppressions = newSuppressions;
+            Tree declaration) {
+        this.desiredSuppressions = desiredSuppressions;
+        this.sourceCode = sourceCode;
+        this.suppressWarnings = suppressWarnings;
 
-        // There is an additional issue that by the time error-prone comes around to apply the replacements, the
-        // compiler seems to change the representation of the tree for another phase - `App.Builder` becomes
-        // `App$Builder` etc and the start position for the expression changes to be after `App` rather than at the
-        // start of `App`. If we calculate the replacement range too late, we insert our @SuppressWarnings at the
-        // wrong location, and the indentation is miscalculated. But we can't calculate the replacement string
-        // straight away, as we might not have all the new suppressions added yet. So we have to immediately
-        // calculate the replacement range and indentation/suffix, but hold off building the final replacement
-        // string until we have all the new suppressions.
-        this.range = calculateRange(endPositions, suppressWarnings, tree);
+        // Calculate range immediately to avoid tree representation changes
+        this.range = calculateRange(endPositions, suppressWarnings, declaration);
 
         this.suffix = suppressWarnings
                 // If we're replacing an existing @SuppressWarnings, there's no need to add an indent
                 .map(_ignored -> "")
                 // If we're adding a new @SuppressWarnings, we need to indent the next line correctly
-                .orElseGet(() -> "\n" + SourceCodeUtils.indentForTree(sourceCode, tree));
+                .orElseGet(() -> "\n" + SourceCodeUtils.indentForTree(sourceCode, declaration));
 
         this.existingSuppressions = suppressWarnings.stream()
                 .flatMap(AnnotationUtils::annotationStringValues)
@@ -71,13 +66,32 @@ final class SuppressingReplacement extends Replacement {
 
     @Override
     public Range<Integer> range() {
+        if (desiredSuppressions.isEmpty() && sourceCode.isPresent()) {
+            // If the next element is in a newline, remove the newline as well.
+            // Ideally, we also remove whitespace before the next element, but that would overlap with any done on
+            // the next element. We leave those spaces to the formatter.
+            // Otherwise, the next element is a non-whitespace. Remove up until the first non-whitespace.
+            int end = SourceCodeUtils.firstNonWhitespaceOrNextLineStart(sourceCode.get(), range.upperEndpoint());
+            return Range.closedOpen(range.lowerEndpoint(), end);
+        }
         return range;
     }
 
     @Override
     public String replaceWith() {
+        String result = calculateReplacementText();
+        return result;
+    }
+
+    private String calculateReplacementText() {
+        if (desiredSuppressions.isEmpty()) {
+            // No suppressions left, return empty string (line removal will be handled by range())
+            return "";
+        }
+
+        // Generate the @SuppressWarnings annotation with remaining suppressions
         return SuppressWarningsUtils.suppressWarningsString(
-                        SuppressWarningsUtils.modifySuppressions(existingSuppressions, newSuppressions))
+                        SuppressWarningsUtils.sortHumanFirstThenAlphabetical(desiredSuppressions))
                 + suffix;
     }
 
@@ -85,7 +99,7 @@ final class SuppressingReplacement extends Replacement {
             EndPosTable endPositions, Optional<? extends AnnotationTree> suppressWarnings, Tree tree) {
         return suppressWarnings
                 .map(annotationTree -> {
-                    // @SuppressWarnings already exists, we need to replace the whole expression with our own
+                    // @SuppressWarnings already exists, we need to replace the whole expression
                     DiagnosticPosition position = (DiagnosticPosition) annotationTree;
                     return Range.closedOpen(position.getStartPosition(), position.getEndPosition(endPositions));
                 })

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressions.java
@@ -17,19 +17,15 @@
 package com.palantir.suppressibleerrorprone;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.fixes.Fix;
-import com.google.errorprone.fixes.Replacement;
-import com.google.errorprone.fixes.Replacements.CoalescePolicy;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.AnnotationTree;
-import com.sun.tools.javac.tree.EndPosTable;
-import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
-import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+import com.sun.source.tree.Tree;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Name;
@@ -87,81 +83,12 @@ public final class RemoveRolloutSuppressions extends BugChecker implements BugCh
             return Description.NO_MATCH;
         }
 
-        String updatedText = SuppressWarningsUtils.suppressWarningsString(updatedSuppressions);
-
-        return buildDescription(tree)
-                .addFix(new LineRemovingReplacementFix(state.getSourceCode(), (DiagnosticPosition) tree, updatedText))
-                .build();
-    }
-
-    /**
-     * This class has been introduced because the normal {@link com.google.errorprone.fixes.SuggestedFix} does not
-     *   allow us to introduce a Replacement which has a different start position than the tree's normal start position.
-     * Here we want to:
-     *   - replace the element defined by the provided position
-     *   - also replace the whitespace before the element, up to and including the newline
-     * This way, if e.g. @SuppressWarnings("foo") must be removed entirely, we can remove the entire line, rather than
-     *   just the annotation, leaving us with an empty line.
-     *
-     * Note that this will only delete the whitespace before the element if the entire element is removed
-     *   (i.e. if the replacement text is null or empty).
-     */
-    private static final class LineRemovingReplacementFix implements Fix {
-        private final CharSequence sourceCode;
-        private final DiagnosticPosition position;
-        private final String replacementText;
-
-        private LineRemovingReplacementFix(
-                CharSequence sourceCode, DiagnosticPosition position, String replacementText) {
-            this.sourceCode = sourceCode;
-            this.position = position;
-            this.replacementText = replacementText;
-        }
-
-        @Override
-        public String toString(JCCompilationUnit compilationUnit) {
-            return "LineRemovingReplacementFix";
-        }
-
-        @Override
-        public String getShortDescription() {
-            return "Replace text at the position with the provided text, "
-                    + "or remove the text and all preceding whitespace";
-        }
-
-        @Override
-        public CoalescePolicy getCoalescePolicy() {
-            return CoalescePolicy.REJECT;
-        }
-
-        @Override
-        public ImmutableSet<Replacement> getReplacements(EndPosTable endPositions) {
-            if (replacementText.isEmpty() && sourceCode != null) {
-                // If the next element is in a newline, remove the newline as well.
-                // Ideally, we also remove whitespace before the next element, but that would overlap with any done on
-                // the next element. We leave those spaces to the formatter.
-                // Otherwise, the next element is a non-whitespace. Remove up until the first non-whitespace.
-                int end = SourceCodeUtils.firstNonWhitespaceOrNextLineStart(
-                        sourceCode, position.getEndPosition(endPositions));
-                return ImmutableSet.of(Replacement.create(position.getStartPosition(), end, ""));
-            }
-            return ImmutableSet.of(Replacement.create(
-                    position.getStartPosition(), position.getEndPosition(endPositions), replacementText));
-        }
-
-        @Override
-        public ImmutableSet<String> getImportsToAdd() {
-            return ImmutableSet.of();
-        }
-
-        @Override
-        public ImmutableSet<String> getImportsToRemove() {
-            return ImmutableSet.of();
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
+        Tree declaration = state.getPath().getParentPath().getParentPath().getLeaf();
+        LazySuppressionFix fix = new LazySuppressionFix(
+                Optional.ofNullable(state.getSourceCode()),
+                Optional.of(tree),
+                declaration,
+                new HashSet<>(updatedSuppressions));
+        return buildDescription(tree).addFix(fix).build();
     }
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsUtils.java
@@ -22,6 +22,8 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +39,14 @@ final class SuppressWarningsUtils {
         public static SuppressionsType fromName(String name) {
             return name.startsWith(CommonConstants.AUTOMATICALLY_ADDED_PREFIX) ? AUTOMATICALLY_ADDED : HUMAN_AUTHORED;
         }
+    }
+
+    public static List<String> sortHumanFirstThenAlphabetical(Collection<String> suppressions) {
+        return suppressions.stream()
+                .sorted(Comparator.comparing((String suppression) ->
+                                SuppressionsType.fromName(suppression) == SuppressionsType.AUTOMATICALLY_ADDED)
+                        .thenComparing(String::compareTo))
+                .collect(Collectors.toList());
     }
 
     public static List<String> modifySuppressions(

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -35,6 +35,7 @@ import java.util.WeakHashMap;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import javax.lang.model.element.Name;
+
 // CHECKSTYLE:ON
 
 public final class VisitorStateModifications {
@@ -119,7 +120,7 @@ public final class VisitorStateModifications {
                 _ignored -> LazySuppressionFix.empty(
                         Optional.ofNullable(visitorState.getSourceCode()), suppressWarnings, firstSuppressibleParent));
 
-        suppressingFix.addSuppression(description.checkName);
+        suppressingFix.addSuppression(CommonConstants.AUTOMATICALLY_ADDED_PREFIX + description.checkName);
 
         // If we already submitted our mutable fix, we don't need to do so again, just need to add the error to the fix.
         if (alreadyReportedFix) {

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -44,7 +44,7 @@ public final class VisitorStateModifications {
     // mutable fixes values around forever, once error-prone has finished with the source element tree used as a key
     // here (once the file has been visited by all the error-prone checks), our SuppressingFixes can be safely
     // garbage collected.
-    private static final Map<Tree, SuppressingFix> FIXES = new WeakHashMap<>();
+    private static final Map<Tree, LazySuppressionFix> FIXES = new WeakHashMap<>();
 
     @SuppressWarnings("RestrictedApi")
     public static Description interceptDescription(VisitorState visitorState, Description description) {
@@ -114,9 +114,9 @@ public final class VisitorStateModifications {
         // the error-prone checks it will then produce a replacement with all the checks suppressed.
         boolean alreadyReportedFix = FIXES.containsKey(firstSuppressibleParent);
 
-        SuppressingFix suppressingFix = FIXES.computeIfAbsent(
+        LazySuppressionFix suppressingFix = FIXES.computeIfAbsent(
                 firstSuppressibleParent,
-                _ignored -> new SuppressingFix(
+                _ignored -> LazySuppressionFix.empty(
                         Optional.ofNullable(visitorState.getSourceCode()), suppressWarnings, firstSuppressibleParent));
 
         suppressingFix.addSuppression(description.checkName);

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.Name;
 
@@ -115,10 +116,20 @@ public final class VisitorStateModifications {
         // the error-prone checks it will then produce a replacement with all the checks suppressed.
         boolean alreadyReportedFix = FIXES.containsKey(firstSuppressibleParent);
 
-        LazySuppressionFix suppressingFix = FIXES.computeIfAbsent(
-                firstSuppressibleParent,
-                _ignored -> LazySuppressionFix.empty(
-                        Optional.ofNullable(visitorState.getSourceCode()), suppressWarnings, firstSuppressibleParent));
+        LazySuppressionFix suppressingFix = FIXES.computeIfAbsent(firstSuppressibleParent, _ignored -> {
+            // Initialize every fix with all remove-rollout: suppressions removed
+            Stream<String> existingSuppressions = suppressWarnings
+                    .map(AnnotationUtils::annotationStringValues)
+                    .orElseGet(Stream::of);
+            Set<String> existingNonRolloutSuppressions = existingSuppressions
+                    .filter(sup -> !sup.startsWith(CommonConstants.AUTOMATICALLY_ADDED_PREFIX))
+                    .collect(Collectors.toSet());
+            return new LazySuppressionFix(
+                    Optional.ofNullable(visitorState.getSourceCode()),
+                    suppressWarnings,
+                    firstSuppressibleParent,
+                    existingNonRolloutSuppressions);
+        });
 
         suppressingFix.addSuppression(CommonConstants.AUTOMATICALLY_ADDED_PREFIX + description.checkName);
 

--- a/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressionsTest.java
+++ b/suppressible-error-prone/src/test/java/com/palantir/suppressibleerrorprone/RemoveRolloutSuppressionsTest.java
@@ -178,19 +178,19 @@ class RemoveRolloutSuppressionsTest {
     }
 
     @Test
-    void do_not_reorder_existing_annotations() {
+    void sorts_by_human_authored_first_then_by_alnum() {
         fix().addInputLines(
                         "App.java",
                         // language=Java
                         """
-                        @SuppressWarnings({"for-rollout:3", "for-rollout:2", "1"})
+                        @SuppressWarnings({"for-rollout:3", "for-rollout:2", "for-rollout:1", "b", "a"})
                         public final class App {}
                         """)
                 .addOutputLines(
                         "App.java",
                         // language=Java
                         """
-                        @SuppressWarnings({"for-rollout:3", "1"})
+                        @SuppressWarnings({"a", "b", "for-rollout:1", "for-rollout:3"})
                         public final class App {}
                         """)
                 .setArgs("-XepOpt:" + RemoveRolloutSuppressions.ARGUMENT + "=2")


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are working on `-PerrorProneRemoveUnused`, a mode which removes all unused suppressions. This mode requires us to lazily remove items from a `@SuppressWarnings` fix, and defer rendering the replacement until after all BugCheckers have been evaluated.

We already have a `SuppressingFix` which does the lazy evaluation when adding suppressions, and `LineRemovingReplacementFix` which handles removing suppression with proper line handling. Lets combine the functionality of both.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Create a `LazySuppressionFix` to allow for lazily adding/removing suppressions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

