### PR TITLE
Add the ability to ignore suppressions in `SuppressibleTreePathScanner`

### DIFF
--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java
@@ -19,9 +19,11 @@ package com.palantir.gradle.suppressibleerrorprone;
 import com.palantir.gradle.suppressibleerrorprone.modes.Modes;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.CommonOptions;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption;
+import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.ModifiedFile;
 import com.palantir.gradle.suppressibleerrorprone.transform.ModifyErrorProneCheckApi;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
@@ -75,7 +77,7 @@ public abstract class SuppressibleErrorPronePlugin implements Plugin<Project> {
         if (getModes().modifyCheckApi() instanceof ModifyCheckApiOption.MustModify mustModify) {
             // When auto-suppressing, the logic will run a bytecode patched version of errorprone
             // (via an artifact transform) that intercepts every error from every check and adds a custom fix
-            setupErrorProneArtifactTransform(project, mustModify.modifyVisitorState());
+            setupErrorProneArtifactTransform(project, mustModify.modifiedFiles());
         }
 
         project.getConfigurations().named(ErrorPronePlugin.CONFIGURATION_NAME).configure(errorProneConfiguration -> {
@@ -108,7 +110,7 @@ public abstract class SuppressibleErrorPronePlugin implements Plugin<Project> {
         });
     }
 
-    private static void setupErrorProneArtifactTransform(Project project, boolean modifyVisitorState) {
+    private static void setupErrorProneArtifactTransform(Project project, Set<ModifiedFile> modifiedFiles) {
         Attribute<Boolean> suppressible =
                 Attribute.of("com.palantir.suppressible-error-prone.suppressible", Boolean.class);
         project.getDependencies().getAttributesSchema().attribute(suppressible);
@@ -120,7 +122,7 @@ public abstract class SuppressibleErrorPronePlugin implements Plugin<Project> {
                 .attribute(suppressible, false);
 
         project.getDependencies().registerTransform(ModifyErrorProneCheckApi.class, spec -> {
-            spec.getParameters().getModifyVisitorState().set(modifyVisitorState);
+            spec.getParameters().getFilesToModify().set(modifiedFiles);
 
             Attribute<String> artifactType = Attribute.of("artifactType", String.class);
             spec.getFrom().attribute(suppressible, false).attribute(artifactType, "jar");
@@ -204,6 +206,10 @@ public abstract class SuppressibleErrorPronePlugin implements Plugin<Project> {
                                 commonOptions.patchChecks().asCommaSeparated().orElse(null)));
 
         errorProneOptions.getErrorproneArgumentProviders().add(patchChecksCommandLineArgumentProvider);
+
+        errorProneOptions
+                .getIgnoreSuppressionAnnotations()
+                .set(getProviderFactory().provider(commonOptions::ignoreSuppressionAnnotations));
 
         errorProneOptions
                 .getCheckOptions()

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import one.util.streamex.EntryStream;
 
 /**
@@ -57,8 +56,7 @@ public interface CommonOptions {
             public Map<String, String> extraErrorProneCheckOptions() {
                 return EntryStream.of(CommonOptions.this.extraErrorProneCheckOptions())
                         .append(other.extraErrorProneCheckOptions())
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey, Map.Entry::getValue, (val1, val2) -> val1 + "," + val2));
+                        .toMap();
             }
 
             @Override

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import one.util.streamex.EntryStream;
 
 /**
@@ -41,6 +42,10 @@ public interface CommonOptions {
         return RemoveRolloutCheck.DISABLE;
     }
 
+    default boolean ignoreSuppressionAnnotations() {
+        return false;
+    }
+
     default CommonOptions naivelyCombinedWith(CommonOptions other) {
         return new CommonOptions() {
             @Override
@@ -52,12 +57,18 @@ public interface CommonOptions {
             public Map<String, String> extraErrorProneCheckOptions() {
                 return EntryStream.of(CommonOptions.this.extraErrorProneCheckOptions())
                         .append(other.extraErrorProneCheckOptions())
-                        .toMap();
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey, Map.Entry::getValue, (val1, val2) -> val1 + "," + val2));
             }
 
             @Override
             public RemoveRolloutCheck removeRolloutCheck() {
                 return CommonOptions.this.removeRolloutCheck().or(other.removeRolloutCheck());
+            }
+
+            @Override
+            public boolean ignoreSuppressionAnnotations() {
+                return CommonOptions.this.ignoreSuppressionAnnotations() || other.ignoreSuppressionAnnotations();
             }
         };
     }
@@ -69,15 +80,25 @@ public interface CommonOptions {
     default CommonOptions withExtraErrorProneCheckFlag(String key, Supplier<String> value) {
         return new CommonOptions() {
             @Override
+            public Map<String, String> extraErrorProneCheckOptions() {
+                Map<String, String> map = new HashMap<>(CommonOptions.this.extraErrorProneCheckOptions());
+                map.put(key, value.get());
+                return Collections.unmodifiableMap(map);
+            }
+
+            @Override
             public PatchChecksOption patchChecks() {
                 return CommonOptions.this.patchChecks();
             }
 
             @Override
-            public Map<String, String> extraErrorProneCheckOptions() {
-                Map<String, String> map = new HashMap<>(CommonOptions.this.extraErrorProneCheckOptions());
-                map.put(key, value.get());
-                return Collections.unmodifiableMap(map);
+            public RemoveRolloutCheck removeRolloutCheck() {
+                return CommonOptions.this.removeRolloutCheck();
+            }
+
+            @Override
+            public boolean ignoreSuppressionAnnotations() {
+                return CommonOptions.this.ignoreSuppressionAnnotations();
             }
         };
     }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/ModifyCheckApiOption.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/ModifyCheckApiOption.java
@@ -19,12 +19,9 @@ package com.palantir.gradle.suppressibleerrorprone.modes.common;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.DoNotModify;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.MustModify;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.NoEffect;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import one.util.streamex.StreamEx;
 
 /**
@@ -53,7 +50,7 @@ public sealed interface ModifyCheckApiOption permits DoNotModify, NoEffect, Must
      * Modify these files in the error-prone API.
      */
     static MustModify mustModify(ModifiedFile... modifiedFile) {
-        return new MustModify(Arrays.stream(modifiedFile).collect(Collectors.toSet()));
+        return new MustModify(Set.of(modifiedFile));
     }
 
     default Set<ModifiedFile> getModifiedFiles() {
@@ -71,8 +68,8 @@ public sealed interface ModifyCheckApiOption permits DoNotModify, NoEffect, Must
 
     record MustModify(Set<ModifiedFile> modifiedFiles) implements ModifyCheckApiOption, CombinedValue {
         public MustModify combine(MustModify other) {
-            Set<ModifiedFile> union = Stream.concat(modifiedFiles.stream(), other.modifiedFiles.stream())
-                    .collect(Collectors.toSet());
+            Set<ModifiedFile> union =
+                    StreamEx.of(modifiedFiles).append(other.modifiedFiles).toSet();
             return new MustModify(union);
         }
     }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/ModifyCheckApiOption.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/ModifyCheckApiOption.java
@@ -19,9 +19,12 @@ package com.palantir.gradle.suppressibleerrorprone.modes.common;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.DoNotModify;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.MustModify;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.NoEffect;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import one.util.streamex.StreamEx;
 
 /**
@@ -47,19 +50,16 @@ public sealed interface ModifyCheckApiOption permits DoNotModify, NoEffect, Must
     }
 
     /**
-     * The {@code error_prone_check_api} jar must be modified to allow {@code `for-rollout:`} suppressions to work.
+     * Modify these files in the error-prone API.
      */
-    static ModifyCheckApiOption mustModify() {
-        return new MustModify(false);
+    static MustModify mustModify(ModifiedFile... modifiedFile) {
+        return new MustModify(Arrays.stream(modifiedFile).collect(Collectors.toSet()));
     }
 
-    /**
-     * The {@code error_prone_check_api} jar must be modified to allow {@code `for-rollout:`} suppressions to work,
-     * and {@code VisitorState} must be modified to intercept reportMatch.
-     */
-    static ModifyCheckApiOption mustModifyIncludingVisitorState() {
-        return new MustModify(true);
+    default Set<ModifiedFile> getModifiedFiles() {
+        return Set.of();
     }
+    ;
 
     enum DoNotModify implements ModifyCheckApiOption, CombinedValue {
         INSTANCE
@@ -69,9 +69,11 @@ public sealed interface ModifyCheckApiOption permits DoNotModify, NoEffect, Must
         INSTANCE
     }
 
-    record MustModify(boolean modifyVisitorState) implements ModifyCheckApiOption, CombinedValue {
+    record MustModify(Set<ModifiedFile> modifiedFiles) implements ModifyCheckApiOption, CombinedValue {
         public MustModify combine(MustModify other) {
-            return new MustModify(modifyVisitorState || other.modifyVisitorState);
+            Set<ModifiedFile> union = Stream.concat(modifiedFiles.stream(), other.modifiedFiles.stream())
+                    .collect(Collectors.toSet());
+            return new MustModify(union);
         }
     }
 
@@ -84,7 +86,7 @@ public sealed interface ModifyCheckApiOption permits DoNotModify, NoEffect, Must
 
         if (withoutNoEffects.isEmpty()) {
             // By default, we need to modify the check API to support for-rollout suppressions
-            return new MustModify(false);
+            return mustModify(ModifiedFile.BUG_CHECKER_INFO);
         }
 
         boolean doNotModify = withoutNoEffects.contains(DoNotModify.INSTANCE);
@@ -102,5 +104,17 @@ public sealed interface ModifyCheckApiOption permits DoNotModify, NoEffect, Must
                 .map(MustModify.class::cast)
                 .reduce(MustModify::combine)
                 .get();
+    }
+
+    enum ModifiedFile {
+        BUG_CHECKER_INFO("BugCheckerInfo"),
+        VISITOR_STATE("VisitorState"),
+        SUPPRESSIBLE_TREE_PATH_SCANNER("SuppressibleTreePathScanner");
+
+        private final String className;
+
+        ModifiedFile(String className) {
+            this.className = className;
+        }
     }
 }

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/modes/SuppressMode.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/modes/SuppressMode.java
@@ -19,12 +19,13 @@ package com.palantir.gradle.suppressibleerrorprone.modes.modes;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.CommonOptions;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.Mode;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption;
+import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.ModifiedFile;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.PatchChecksOption;
 
 public final class SuppressMode implements Mode {
     @Override
     public ModifyCheckApiOption modifyCheckApi() {
-        return ModifyCheckApiOption.mustModifyIncludingVisitorState();
+        return ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE);
     }
 
     @Override

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/ModifyErrorProneCheckApi.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/ModifyErrorProneCheckApi.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
 import java.util.jar.JarFile;
@@ -81,8 +82,10 @@ public abstract class ModifyErrorProneCheckApi implements TransformAction<Params
         // We always want to modify the BugCheckerInfo class, as this is where we help errorprone understand
         // what the `for-rollout:` prefix for suppressions mean (which means this class is always modified,
         // even during normal compilation).
+
+        Set<ModifiedFile> filesToModify = getParameters().getFilesToModify().get();
         if (classJarPath.equals("com/google/errorprone/BugCheckerInfo.class")
-                && getParameters().getFilesToModify().get().contains(ModifiedFile.BUG_CHECKER_INFO)) {
+                && filesToModify.contains(ModifiedFile.BUG_CHECKER_INFO)) {
             return Optional.of(BugCheckerInfoVisitor::new);
         }
 
@@ -90,12 +93,12 @@ public abstract class ModifyErrorProneCheckApi implements TransformAction<Params
         // it intercepts all errors and changes them. So when we're just running normal compilation, we want
         // to avoid running our modifications at all, and let the errors continue on their way unchanged.
         if (classJarPath.equals("com/google/errorprone/VisitorState.class")
-                && getParameters().getFilesToModify().get().contains(ModifiedFile.VISITOR_STATE)) {
+                && filesToModify.contains(ModifiedFile.VISITOR_STATE)) {
             return Optional.of(VisitorStateClassVisitor::new);
         }
 
         if (classJarPath.equals("com/google/errorprone/bugpatterns/BugChecker$SuppressibleTreePathScanner.class")
-                && getParameters().getFilesToModify().get().contains(ModifiedFile.SUPPRESSIBLE_TREE_PATH_SCANNER)) {
+                && filesToModify.contains(ModifiedFile.SUPPRESSIBLE_TREE_PATH_SCANNER)) {
             return Optional.of(SuppressibleTreePathScannerClassVisitor::new);
         }
 

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/ModifyErrorProneCheckApi.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/ModifyErrorProneCheckApi.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.suppressibleerrorprone.transform;
 
+import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.ModifiedFile;
 import com.palantir.gradle.suppressibleerrorprone.transform.ModifyErrorProneCheckApi.Params;
 import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import java.io.BufferedOutputStream;
@@ -36,6 +37,7 @@ import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.objectweb.asm.ClassReader;
@@ -67,7 +69,7 @@ public abstract class ModifyErrorProneCheckApi implements TransformAction<Params
         visitJar(output, (classJarPath, inputStream) -> classVisitorFor(classJarPath)
                 .map(classVisitorFactory -> {
                     ClassReader classReader = newClassReader(inputStream);
-                    ClassWriter classWriter = new ClassWriter(classReader, 0);
+                    ClassWriter classWriter = new ClassWriter(classReader, ClassWriter.COMPUTE_FRAMES);
                     ClassVisitor classVisitor = classVisitorFactory.apply(classWriter);
 
                     classReader.accept(classVisitor, 0);
@@ -79,7 +81,8 @@ public abstract class ModifyErrorProneCheckApi implements TransformAction<Params
         // We always want to modify the BugCheckerInfo class, as this is where we help errorprone understand
         // what the `for-rollout:` prefix for suppressions mean (which means this class is always modified,
         // even during normal compilation).
-        if (classJarPath.equals("com/google/errorprone/BugCheckerInfo.class")) {
+        if (classJarPath.equals("com/google/errorprone/BugCheckerInfo.class")
+                && getParameters().getFilesToModify().get().contains(ModifiedFile.BUG_CHECKER_INFO)) {
             return Optional.of(BugCheckerInfoVisitor::new);
         }
 
@@ -87,8 +90,13 @@ public abstract class ModifyErrorProneCheckApi implements TransformAction<Params
         // it intercepts all errors and changes them. So when we're just running normal compilation, we want
         // to avoid running our modifications at all, and let the errors continue on their way unchanged.
         if (classJarPath.equals("com/google/errorprone/VisitorState.class")
-                && getParameters().getModifyVisitorState().get()) {
+                && getParameters().getFilesToModify().get().contains(ModifiedFile.VISITOR_STATE)) {
             return Optional.of(VisitorStateClassVisitor::new);
+        }
+
+        if (classJarPath.equals("com/google/errorprone/bugpatterns/BugChecker$SuppressibleTreePathScanner.class")
+                && getParameters().getFilesToModify().get().contains(ModifiedFile.SUPPRESSIBLE_TREE_PATH_SCANNER)) {
+            return Optional.of(SuppressibleTreePathScannerClassVisitor::new);
         }
 
         return Optional.empty();
@@ -132,7 +140,7 @@ public abstract class ModifyErrorProneCheckApi implements TransformAction<Params
 
     public abstract static class Params implements TransformParameters {
         @Input
-        public abstract Property<Boolean> getModifyVisitorState();
+        public abstract SetProperty<ModifiedFile> getFilesToModify();
 
         @Input
         public abstract Property<String> getCacheBust();

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/SuppressibleTreePathScannerClassVisitor.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/SuppressibleTreePathScannerClassVisitor.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.suppressibleerrorprone.transform;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Forces {@code SuppressibleTreePathScanner} to respect the ignore suppressions option.
+ *
+ * <p>{@code RemoveUnusedSuppressions} must see violations that are normally hidden by suppressions to
+ * determine which suppressions are actually needed. While ErrorProneOptions has an
+ * {@code ignoreSuppressionAnnotations} flag for this purpose, many BugCheckers use
+ * {@code SuppressibleTreePathScanner}, which doesn't respect this flag.
+ *
+ * <p>This class uses bytecode manipulation to patch {@code SuppressibleTreePathScanner::isSuppressed}
+ * to respect the ErrorProneOptions setting.
+ */
+final class SuppressibleTreePathScannerClassVisitor extends ClassVisitor {
+    SuppressibleTreePathScannerClassVisitor(ClassVisitor classVisitor) {
+        super(Opcodes.ASM9, classVisitor);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+            int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+        if (name.equals("suppressed") && descriptor.equals("(Lcom/sun/source/tree/Tree;)Z")) {
+            return new SuppressedMethodVisitor(methodVisitor);
+        }
+
+        return methodVisitor;
+    }
+
+    private static final class SuppressedMethodVisitor extends MethodVisitor {
+        SuppressedMethodVisitor(MethodVisitor methodVisitor) {
+            super(Opcodes.ASM9, methodVisitor);
+        }
+
+        @Override
+        public void visitCode() {
+            super.visitCode();
+            // Load this (SuppressibleTreePathScanner instance)
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            // Get the state field
+            mv.visitFieldInsn(
+                    Opcodes.GETFIELD,
+                    "com/google/errorprone/bugpatterns/BugChecker$SuppressibleTreePathScanner",
+                    "state",
+                    "Lcom/google/errorprone/VisitorState;");
+            // Check condition and potentially return false early
+            mv.visitMethodInsn(
+                    Opcodes.INVOKESTATIC,
+                    "com/palantir/suppressibleerrorprone/SuppressibleTreePathScannerModifications",
+                    "shouldIgnoreSuppressions",
+                    "(Lcom/google/errorprone/VisitorState;)Z",
+                    false);
+
+            // If condition is true, return false immediately
+            Label continueLabel = new Label();
+            mv.visitJumpInsn(Opcodes.IFEQ, continueLabel);
+            mv.visitInsn(Opcodes.ICONST_0); // push false
+            mv.visitInsn(Opcodes.IRETURN);
+            mv.visitLabel(continueLabel);
+            // Add a frame here to fix verification
+            mv.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+        }
+    }
+}

--- a/gradle-suppressible-error-prone/src/test/java/com/palantir/gradle/suppressibleerrorprone/modes/common/ModifyCheckApiOptionTest.java
+++ b/gradle-suppressible-error-prone/src/test/java/com/palantir/gradle/suppressibleerrorprone/modes/common/ModifyCheckApiOptionTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.DoNotModify;
+import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.ModifiedFile;
 import com.palantir.gradle.suppressibleerrorprone.modes.common.ModifyCheckApiOption.MustModify;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -27,36 +28,42 @@ import org.junit.jupiter.api.Test;
 class ModifyCheckApiOptionTest {
     @Test
     void combining_must_modify_instances_with_different_visitor_states_results_in_true() {
-        MustModify withoutVisitorState = new MustModify(false);
-        MustModify withVisitorState = new MustModify(true);
+        MustModify withoutVisitorState = ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO);
+        MustModify withVisitorState =
+                ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE);
 
-        assertThat(withoutVisitorState.combine(withVisitorState).modifyVisitorState())
+        assertThat(withoutVisitorState.combine(withVisitorState).modifiedFiles().contains(ModifiedFile.VISITOR_STATE))
                 .isTrue();
-        assertThat(withVisitorState.combine(withoutVisitorState).modifyVisitorState())
+        assertThat(withVisitorState.combine(withoutVisitorState).modifiedFiles().contains(ModifiedFile.VISITOR_STATE))
                 .isTrue();
     }
 
     @Test
     void combining_must_modify_instances_with_same_visitor_states_preserves_state() {
-        MustModify bothFalse1 = new MustModify(false);
-        MustModify bothFalse2 = new MustModify(false);
-        assertThat(bothFalse1.combine(bothFalse2).modifyVisitorState()).isFalse();
+        MustModify bothFalse1 = ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO);
+        MustModify bothFalse2 = ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO);
+        assertThat(bothFalse1.combine(bothFalse2).modifiedFiles().contains(ModifiedFile.VISITOR_STATE))
+                .isFalse();
 
-        MustModify bothTrue1 = new MustModify(true);
-        MustModify bothTrue2 = new MustModify(true);
-        assertThat(bothTrue1.combine(bothTrue2).modifyVisitorState()).isTrue();
+        MustModify bothTrue1 =
+                ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE);
+        MustModify bothTrue2 =
+                ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE);
+        assertThat(bothTrue1.combine(bothTrue2).modifiedFiles().contains(ModifiedFile.VISITOR_STATE))
+                .isTrue();
     }
 
     @Test
     void combining_empty_collection_returns_must_modify() {
-        assertThat(ModifyCheckApiOption.combine(List.of())).isEqualTo(new MustModify(false));
+        assertThat(ModifyCheckApiOption.combine(List.of()))
+                .isEqualTo(ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO));
     }
 
     @Test
     void combining_only_no_effect_returns_must_modify() {
         assertThat(ModifyCheckApiOption.combine(
                         List.of(ModifyCheckApiOption.noEffect(), ModifyCheckApiOption.noEffect())))
-                .isEqualTo(new MustModify(false));
+                .isEqualTo(ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO));
     }
 
     @Test
@@ -69,25 +76,27 @@ class ModifyCheckApiOptionTest {
 
     @Test
     void combining_must_modify_with_no_effect_causes_no_change() {
-        assertThat(ModifyCheckApiOption.combine(
-                        List.of(ModifyCheckApiOption.mustModify(), ModifyCheckApiOption.noEffect())))
-                .isEqualTo(new MustModify(false));
+        assertThat(ModifyCheckApiOption.combine(List.of(
+                        ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO),
+                        ModifyCheckApiOption.noEffect())))
+                .isEqualTo(ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO));
     }
 
     @Test
     void combining_must_modify_including_visitor_state_with_no_effect_causes_no_change() {
         assertThat(ModifyCheckApiOption.combine(List.of(
-                        ModifyCheckApiOption.mustModifyIncludingVisitorState(), ModifyCheckApiOption.noEffect())))
-                .isEqualTo(new MustModify(true));
+                        ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE),
+                        ModifyCheckApiOption.noEffect())))
+                .isEqualTo(ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE));
     }
 
     @Test
     void combining_multiple_must_modify_options_combines_visitor_states() {
         assertThat(ModifyCheckApiOption.combine(List.of(
-                        ModifyCheckApiOption.mustModify(),
-                        ModifyCheckApiOption.mustModifyIncludingVisitorState(),
+                        ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO),
+                        ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE),
                         ModifyCheckApiOption.noEffect())))
-                .isEqualTo(new MustModify(true));
+                .isEqualTo(ModifyCheckApiOption.mustModify(ModifiedFile.BUG_CHECKER_INFO, ModifiedFile.VISITOR_STATE));
     }
 
     @Test

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressibleTreePathScannerModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressibleTreePathScannerModifications.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.suppressibleerrorprone;
+
+import com.google.errorprone.VisitorState;
+
+public class SuppressibleTreePathScannerModifications {
+
+    public static boolean shouldIgnoreSuppressions(VisitorState state) {
+        return state.errorProneOptions().isIgnoreSuppressionAnnotations();
+    }
+
+    private SuppressibleTreePathScannerModifications() {}
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are working on `-PerrorProneRemoveUnused`, a mode which removes all unused suppressions. This mode requires us to turn on the ignore suppressions option in error-prone, or else we can't descend into suppressed trees to chec. 

Error-prone's `SuppressibleTreePathScanner` doesn't respect this flag. This is not expected behavior, as [`ErrorProneScanner` respects the flag](https://github.com/google/error-prone/blob/ac2eaec7616878ad3f2ccfb8d964892146257b39/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java#L503). We've opened https://github.com/google/error-prone/pull/5255, but I think it will take some time to be merged. In the mean time, let's add the option to insert some bytecode so the `SuppressibleTreePathScanner` respects this flag when we need it to.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add the ability to ignore suppressions in `SuppressibleTreePathScanner`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

