### PR TITLE
Ensure we use the correct module args for test-error-prones

### DIFF
--- a/test-error-prone-checks/build.gradle
+++ b/test-error-prone-checks/build.gradle
@@ -22,3 +22,10 @@ publishing {
 tasks.withType(PublishToMavenRepository).configureEach {
     onlyIf { repo -> repo.repository.name == 'MavenLocal' }
 }
+
+moduleJvmArgs {
+    exports(
+        'jdk.compiler/com.sun.tools.javac.code',
+        'jdk.compiler/com.sun.tools.javac.tree',
+        'jdk.compiler/com.sun.tools.javac.util')
+}


### PR DESCRIPTION
## Before this PR
As I was trying to fix `moduleJvmArgs` applying `--add-exports` to `compilerArgs` rather than `forkArgs`, I tested in this repo and it didn't work. It's because that bug has been hiding the fact these exports are needed.

## After this PR
Fix the exports for the testing error-prones.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

