### PR TITLE
Fix removeUnused mode over- and under-removing suppressions

### DIFF
--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -76,6 +76,8 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                 // This should guarantee that we're using the same version, both of which should be in maven local
                 //   and be the current version
                 errorprone 'com.palantir.suppressible-error-prone:test-error-prone-checks:' + project.findProperty("suppressibleErrorProneVersion")
+                errorprone "com.uber.nullaway:nullaway:0.12.12"
+                // NullAway is turned off by default, but is used in some tests
             }
             
             suppressibleErrorProne {
@@ -83,7 +85,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
                     // These interfere with some tests, so disable them
                     // TODO(callumr): Rewrite the tests to use custom testing error-prones rather than built in checks
                     //                to make upgrading error-prone easier.
-                    disable('Varifier', 'ReturnValueIgnored', 'UnusedVariable', 'IdentifierName', 'UnusedMethod')
+                    disable('Varifier', 'ReturnValueIgnored', 'UnusedVariable', 'IdentifierName', 'UnusedMethod', 'NullAway')
                     ignoreUnknownCheckNames = true
                 }
             }
@@ -1596,7 +1598,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         writeJavaSourceFileToSourceSets '''
             package app;
 
-            @SuppressWarnings({"ArrayToString", "UnnecessaryFinal", "InlineTrivialConstant", "NotAnErrorProne", "checkstyle:Bla",})
+            @SuppressWarnings({"ArrayToString", "UnnecessaryFinal", "InlineTrivialConstant", "NotAnErrorProne", "ShouldBePrivate", "checkstyle:Bla",})
             public final class App {
                 private static final String EMPTY_STRING = "";
  
@@ -1607,7 +1609,7 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         '''.stripIndent(true)
 
         when:
-        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveUnused=ArrayToString')
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveUnused')
 
         then:
         // language=Java
@@ -1624,6 +1626,73 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
             }
         '''.stripIndent(true)
     }
+
+    // See SuppressionRemover#DO_NOT_REMOVE
+    def 'errorProneRemoveUnused leaves certain suppressions untouched'() {
+        // language=Java
+        def initialSource = '''
+            package app;
+
+            @SuppressWarnings({"NullAway", "for-rollout:rawtypes"})
+            public final class App {
+                private static final String EMPTY_STRING = "";
+
+                public static void main(String[] args) {
+                    new int[3].toString();
+                }
+            }
+        '''.stripIndent(true)
+        writeJavaSourceFileToSourceSets initialSource
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveUnused')
+        then:
+        // language=Java
+        javaSourceIsSyntacticallyEqualTo initialSource
+    }
+
+    def 'errorProneRemoveUnused understands alt-names'() {
+        // language=Java
+        writeJavaSourceFileToSourceSets '''
+            package app;
+
+            public final class App {
+                @SuppressWarnings("ShouldBePrivate")
+                void fixme(String s) {}
+
+                @SuppressWarnings("MustBePrivate")
+                void fixme(Integer s) {}
+                
+                @SuppressWarnings("ShouldBePrivate")
+                private void fixme(Float s) {}
+
+                @SuppressWarnings("MustBePrivate")
+                private void fixme(Character s) {}
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveUnused')
+
+        then:
+        // language=Java
+        javaSourceIsSyntacticallyEqualTo '''
+            package app;
+
+            public final class App {
+                @SuppressWarnings("ShouldBePrivate")
+                void fixme(String s) {}
+
+                @SuppressWarnings("MustBePrivate")
+                void fixme(Integer s) {}
+                
+                private void fixme(Float s) {}
+
+                private void fixme(Character s) {}
+            }
+        '''.stripIndent(true)
+    }
+
+
 
     def 'errorProneRemoveUnused does not apply fixes'() {
         given:

--- a/suppressible-error-prone/build.gradle
+++ b/suppressible-error-prone/build.gradle
@@ -21,7 +21,9 @@ moduleJvmArgs {
             'jdk.compiler/com.sun.tools.javac.comp',
             'jdk.compiler/com.sun.tools.javac.file',
             'jdk.compiler/com.sun.tools.javac.main',
+            'jdk.compiler/com.sun.tools.javac.model',
             'jdk.compiler/com.sun.tools.javac.parser',
+            'jdk.compiler/com.sun.tools.javac.processing',
             'jdk.compiler/com.sun.tools.javac.tree',
             'jdk.compiler/com.sun.tools.javac.util')
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/AllErrorprones.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/AllErrorprones.java
@@ -16,33 +16,63 @@
 
 package com.palantir.suppressibleerrorprone;
 
-import com.google.common.base.Suppliers;
 import com.google.errorprone.BugCheckerInfo;
+import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.scanner.BuiltInCheckerSuppliers;
+import com.google.errorprone.suppliers.Supplier;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import one.util.streamex.EntryStream;
 import one.util.streamex.StreamEx;
 
 public final class AllErrorprones {
-    private static Supplier<Set<String>> cachedAllBugcheckerNames = Suppliers.memoize(() -> {
-        Stream<BugChecker> pluginChecks =
-                ServiceLoader.load(BugChecker.class).stream().map(ServiceLoader.Provider::get);
-        Stream<String> pluginCheckNames =
-                StreamEx.of(pluginChecks).flatMap(bugchecker -> bugchecker.allNames().stream());
+    private static Supplier<Map<String, Set<String>>> canonicalToAllNames = VisitorState.memoize(state -> {
+        // Use the same classloader that Error Prone was loaded from to avoid classloader skew
+        // when using Error Prone plugins together with the Error Prone javac plugin.
+        JavacProcessingEnvironment processingEnvironment = JavacProcessingEnvironment.instance(state.context);
+        ClassLoader loader = processingEnvironment.getProcessorClassLoader();
+        List<BugChecker> pluginChecks = ServiceLoader.load(BugChecker.class, loader).stream()
+                .map(Provider::get)
+                .collect(Collectors.toList());
+        EntryStream<String, Set<String>> pluginCheckNames =
+                StreamEx.of(pluginChecks).mapToEntry(BugChecker::canonicalName, BugChecker::allNames);
 
         Stream<BugCheckerInfo> builtInChecks = BuiltInCheckerSuppliers.allChecks().getAllChecks().values().stream();
-        Stream<String> builtInCheckNames =
-                StreamEx.of(builtInChecks).flatMap(bugchecker -> bugchecker.allNames().stream());
+        EntryStream<String, Set<String>> builtInCheckNames =
+                StreamEx.of(builtInChecks).mapToEntry(BugCheckerInfo::canonicalName, BugCheckerInfo::allNames);
 
-        return Stream.concat(pluginCheckNames, builtInCheckNames).collect(Collectors.toSet());
+        return pluginCheckNames.append(builtInCheckNames).toMap();
     });
 
-    public static Set<String> allBugcheckerNames() {
-        return cachedAllBugcheckerNames.get();
+    private static Supplier<Set<String>> allNames =
+            VisitorState.memoize(state -> EntryStream.of(canonicalToAllNames.get(state))
+                    .flatMap(entry -> entry.getValue().stream())
+                    .collect(Collectors.toSet()));
+
+    private static Supplier<Map<String, Set<String>>> nameToPossibleCanonicalNames =
+            VisitorState.memoize(state -> EntryStream.of(canonicalToAllNames.get(state))
+                    .flatMapValues(Set::stream)
+                    .invert()
+                    .grouping(Collectors.toSet()));
+
+    public static Set<String> allBugcheckerNames(VisitorState state) {
+        return allNames.get(state);
+    }
+
+    public static Optional<Set<String>> allNames(VisitorState state, String canonicalName) {
+        return Optional.ofNullable(canonicalToAllNames.get(state).get(canonicalName));
+    }
+
+    public static Set<String> possibleCanonicalNames(VisitorState state, String name) {
+        return nameToPossibleCanonicalNames.get(state).getOrDefault(name, Set.of());
     }
 
     private AllErrorprones() {}

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/ReportedFixCache.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/ReportedFixCache.java
@@ -38,15 +38,6 @@ public final class ReportedFixCache {
     // garbage collected.
     private final WeakHashMap<Tree, LazySuppressionFix> cache = new WeakHashMap<>();
 
-    public static final Predicate<String> REMOVE_EVERYTHING = bc -> false;
-    public static final Predicate<String> KEEP_EVERYTHING = bc -> true;
-    public static final Predicate<String> NOT_AN_ERRORPRONE = suppression -> {
-        String checkerName = suppression.startsWith(CommonConstants.AUTOMATICALLY_ADDED_PREFIX)
-                ? suppression.substring(CommonConstants.AUTOMATICALLY_ADDED_PREFIX.length())
-                : suppression;
-        return !AllErrorprones.allBugcheckerNames().contains(checkerName);
-    };
-
     ReportedFixCache() {}
 
     /**

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsUtils.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressWarningsUtils.java
@@ -142,5 +142,12 @@ final class SuppressWarningsUtils {
                 .findFirst();
     }
 
+    public static String stripForRollout(String suppression) {
+        if (suppression.startsWith(CommonConstants.AUTOMATICALLY_ADDED_PREFIX)) {
+            return suppression.substring(12);
+        }
+        return suppression;
+    }
+
     private SuppressWarningsUtils() {}
 }

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressionRemover.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressionRemover.java
@@ -30,12 +30,17 @@ public final class SuppressionRemover {
     // has finished processing.
     private static final Set<CompilationUnitTree> attachedFixes = Collections.newSetFromMap(new WeakHashMap<>());
 
-    private static final Set<String> DO_NOT_REMOVE = Set.of(
+    public static final Set<String> INCOMPATIBLE_WITH_REMOVE_UNUSED = Set.of(
             // NullAway does not respect -XepIgnoreSuppressionAnnotations, and it will take some work to make it so.
             // In the meantime, let's not touch any NullAway suppressions
-            "NullAway", "CheckNullabilityTypes",
+            "NullAway",
+            "CheckNullabilityTypes",
             // rawtypes is used by both the compiler and error-prone, let's not remove these
-            "rawtypes", "RawTypes");
+            "rawtypes",
+            "RawTypes",
+            // The autofix in SafeLoggingPropagation (adding an @Unsafe or @DoNotLog annotation) isn't always
+            // desirable — there are legitimate reasons to suppress it.
+            "SafeLoggingPropagation");
 
     public static void removeAllKnownBugcheckerSuppressions(
             ReportedFixCache reportedFixes, CompilationUnitTree unit, VisitorState state) {
@@ -52,7 +57,8 @@ public final class SuppressionRemover {
                                 state,
                                 suppression -> !AllErrorprones.allBugcheckerNames(state)
                                                 .contains(SuppressWarningsUtils.stripForRollout(suppression))
-                                        || DO_NOT_REMOVE.contains(SuppressWarningsUtils.stripForRollout(suppression)));
+                                        || INCOMPATIBLE_WITH_REMOVE_UNUSED.contains(
+                                                SuppressWarningsUtils.stripForRollout(suppression)));
                     }
 
                     return super.visitAnnotation(node, unused);

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressionRemover.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressionRemover.java
@@ -30,7 +30,14 @@ public final class SuppressionRemover {
     // has finished processing.
     private static final Set<CompilationUnitTree> attachedFixes = Collections.newSetFromMap(new WeakHashMap<>());
 
-    public static void removeAllSuppressionsOnErrorprones(
+    private static final Set<String> DO_NOT_REMOVE = Set.of(
+            // NullAway does not respect -XepIgnoreSuppressionAnnotations, and it will take some work to make it so.
+            // In the meantime, let's not touch any NullAway suppressions
+            "NullAway", "CheckNullabilityTypes",
+            // rawtypes is used by both the compiler and error-prone, let's not remove these
+            "rawtypes", "RawTypes");
+
+    public static void removeAllKnownBugcheckerSuppressions(
             ReportedFixCache reportedFixes, CompilationUnitTree unit, VisitorState state) {
         if (attachedFixes.add(unit)) {
             new TreePathScanner<Void, Void>() {
@@ -40,7 +47,12 @@ public final class SuppressionRemover {
                     if (AnnotationUtils.isSuppressWarningsAnnotation(node)) {
                         TreePath declaration = getCurrentPath().getParentPath().getParentPath();
 
-                        reportedFixes.getOrReportNew(declaration, state, ReportedFixCache.NOT_AN_ERRORPRONE);
+                        reportedFixes.getOrReportNew(
+                                declaration,
+                                state,
+                                suppression -> !AllErrorprones.allBugcheckerNames(state)
+                                                .contains(SuppressWarningsUtils.stripForRollout(suppression))
+                                        || DO_NOT_REMOVE.contains(SuppressWarningsUtils.stripForRollout(suppression)));
                     }
 
                     return super.visitAnnotation(node, unused);

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -24,6 +24,7 @@ import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.util.TreePath;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -50,7 +51,8 @@ public final class VisitorStateModifications {
         if (modes.contains("RemoveUnused")) {
             // Start by removing all suppressions on error-prones, including rollout and human-made.
             // Then, as we encounter Descriptions without fixes, we add back the closest suppression
-            SuppressionRemover.removeAllSuppressionsOnErrorprones(FIXES, compilationUnit, visitorState);
+
+            SuppressionRemover.removeAllKnownBugcheckerSuppressions(FIXES, compilationUnit, visitorState);
         }
 
         // If both -PerrorProneSuppress and -PerrorProneApply are used at the same time, for the checks configured as
@@ -83,13 +85,17 @@ public final class VisitorStateModifications {
 
         Optional<TreePath> firstSuppressibleWhichSuppressesDescription = Stream.iterate(
                         pathToActualError, treePath -> treePath.getParentPath() != null, TreePath::getParentPath)
-                .dropWhile(path -> !suppresses(path, description))
+                .dropWhile(path -> !suppresses(path, description, visitorState))
                 .findFirst();
 
         if (firstSuppressibleWhichSuppressesDescription.isPresent() && modes.contains("RemoveUnused")) {
             // In RemoveUnused mode, removeAllSuppressionsOnErrorprones guarantees that a fix must already exist on
             // this suppressible.
-            FIXES.getExisting(firstSuppressibleWhichSuppressesDescription.get()).addSuppression(description.checkName);
+            TreePath firstSuppressible = firstSuppressibleWhichSuppressesDescription.get();
+            String existingSuppression =
+                    suppressionsOn(firstSuppressible, description, visitorState).get(0);
+            FIXES.getOrReportNew(firstSuppressible, visitorState, suppression -> true)
+                    .addSuppression(existingSuppression);
             return Description.NO_MATCH;
         }
 
@@ -124,26 +130,31 @@ public final class VisitorStateModifications {
         // this, we make sure we only make one fix per source element we put the suppression on by using a Map. This
         // way we have our own mutable Fix that we can add errors to, and only once the file has been visited by all
         // the error-prone checks it will then produce a replacement with all the checks suppressed.
-        LazySuppressionFix suppressingFix =
-                FIXES.getOrReportNew(firstSuppressible.get(), visitorState, ReportedFixCache.KEEP_EVERYTHING);
+        LazySuppressionFix suppressingFix = FIXES.getOrReportNew(firstSuppressible.get(), visitorState, bc -> true);
         suppressingFix.addSuppression(CommonConstants.AUTOMATICALLY_ADDED_PREFIX + description.checkName);
         return Description.NO_MATCH;
     }
 
-    private static boolean suppresses(TreePath declaration, Description description) {
+    private static boolean suppresses(TreePath declaration, Description description, VisitorState state) {
+        return !suppressionsOn(declaration, description, state).isEmpty();
+    }
+
+    private static List<String> suppressionsOn(TreePath declaration, Description description, VisitorState state) {
         if (!SuppressWarningsUtils.suppressibleTreePath(declaration)) {
-            return false;
+            return List.of();
         }
 
         Optional<? extends AnnotationTree> suppressWarningsMaybe =
                 SuppressWarningsUtils.getSuppressWarnings(declaration);
         if (suppressWarningsMaybe.isEmpty()) {
-            return false;
+            return List.of();
         }
 
-        String checkName = description.checkName;
         return AnnotationUtils.annotationStringValues(suppressWarningsMaybe.get())
-                .anyMatch(checkName::equals);
+                .filter(suppression -> AllErrorprones.possibleCanonicalNames(
+                                state, SuppressWarningsUtils.stripForRollout(suppression))
+                        .contains(description.checkName))
+                .toList();
     }
 
     private static Set<String> getModes(VisitorState state) {

--- a/test-error-prone-checks/src/main/java/com/palantir/gradle/suppressibleerrorprone/ShouldNotReturn.java
+++ b/test-error-prone-checks/src/main/java/com/palantir/gradle/suppressibleerrorprone/ShouldNotReturn.java
@@ -20,27 +20,26 @@ import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MethodTree;
-import javax.lang.model.element.Modifier;
 
 @AutoService(BugChecker.class)
 @BugPattern(
         severity = BugPattern.SeverityLevel.ERROR,
-        summary = "This check is meant only for testing suppressible-error-prone functionality",
-        altNames = "MustBePrivate")
-public final class ShouldBePrivate extends BugChecker implements BugChecker.MethodTreeMatcher {
-
+        summary = "This check is meant only for testing suppressible-error-prone functionality")
+public final class ShouldNotReturn extends BugChecker implements MethodTreeMatcher {
     @Override
-    public Description matchMethod(MethodTree tree, VisitorState state) {
-        if (tree.getName().contentEquals("fixme")
-                && !tree.getModifiers().getFlags().contains(Modifier.PRIVATE)) {
-            SuggestedFix fix =
-                    SuggestedFixes.addModifiers(tree, state, Modifier.PRIVATE).orElseGet(SuggestedFix::emptyFix);
-            return buildDescription(tree).addFix(fix).build();
+    public Description matchMethod(MethodTree tree, VisitorState _state) {
+        if (!(tree.getReturnType() instanceof IdentifierTree id)) {
+            return Description.NO_MATCH;
         }
-        return Description.NO_MATCH;
+
+        if (!id.getName().contentEquals("DontReturnMe")) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(id).setMessage("Don't return me").build();
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

A few bugs in suppressible-error-prone:

1. AllBugCheckers wasn't loading any plugin checks
2. RemoveUnused was overzealously removing instances of StrictUnusedVariable and NullAway. This is because they don't respect -XoptIgnoreSuppressionAnnotations. In removeUnused mode, StrictUnusedVariable/Nullaway don't fire due to the the suppression, leading ReportedFixCache to believe that the suppressions aren't used.
3. RemoveUnused mode didn't understand suppressions using alt-names, e.g. SuppressWarnings("unused"), leading it to overzealously remove suppressions

## After this PR

1. AllBugCheckers loads plugin checks
2. Either [fix](https://github.com/palantir/gradle-baseline/pull/3384) or ignore the bugcheckers which don't respect -XoptIgnoreSuppressionAnnotations
3. RemoveUnused mode understands alt-names


<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix removeUnused mode over- and under-removing suppressions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Probably next PR: RemoveUnused should not remove human-made suppressions. For example, a human-made suppression on  [SafeLoggingPropagation](https://github.com/palantir/baseline-error-prone/blob/24e41b5ab7652c72243cde7977c49c71640e0f67/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java#L66) for a method which is safe to log. RemoveUnused + Apply should not remove the suppression and add the `@Unsafe` annotation.

If needed, human-authored suppressions can be removed on an allow-list basis. But the correct and performant removal of robot-added suppressions should be the focus here.
