### PR TITLE
Add the `preferKeepingExistingSuppression` extension property to shunt removeUnused mode for non-standard checks

### DIFF
--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorProneExtension.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorProneExtension.java
@@ -31,11 +31,26 @@ public abstract class SuppressibleErrorProneExtension {
 
     public SuppressibleErrorProneExtension(Project project) {
         this.project = project;
+
+        getPreferKeepingExistingSuppression()
+                .convention(Set.of(
+                        // NullAway does not respect -XepIgnoreSuppressionAnnotations, and it will take some work to
+                        // make it so. In the meantime, let's not touch any NullAway suppressions
+                        "NullAway",
+                        "CheckNullabilityTypes",
+                        // rawtypes is used by both the compiler and error-prone, let's not remove these
+                        "rawtypes",
+                        "RawTypes",
+                        // The autofix in SafeLoggingPropagation (adding an @Unsafe or @DoNotLog annotation) isn't
+                        // always desirable — there are legitimate reasons to suppress it.
+                        "SafeLoggingPropagation"));
     }
 
     public abstract SetProperty<String> getPatchChecks();
 
     public abstract ListProperty<ConditionalPatchCheck> getConditionalPatchChecks();
+
+    public abstract SetProperty<String> getPreferKeepingExistingSuppression();
 
     public final Set<String> patchChecksForCompilation(JavaCompile javaCompile) {
         return Stream.concat(

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/Modes.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/Modes.java
@@ -129,7 +129,17 @@ public abstract class Modes {
                 .append(nonInterferingCommonOptions)
                 .toSet();
 
-        return CommonOptions.naivelyCombine(allCommonOptions);
+        CommonOptions combined = CommonOptions.naivelyCombine(allCommonOptions);
+
+        return combined.withExtraErrorProneCheckFlag(
+                "SuppressibleErrorProne:PreferKeepingExistingSuppression", () -> javaCompile
+                        .getProject()
+                        .getExtensions()
+                        .getByType(com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorProneExtension.class)
+                        .getPreferKeepingExistingSuppression()
+                        .get()
+                        .stream()
+                        .collect(Collectors.joining(",")));
     }
 
     private Map<ModeName, Optional<String>> modesEnabledAndFlagValues() {

--- a/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
+++ b/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/modes/common/CommonOptions.java
@@ -20,8 +20,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import one.util.streamex.EntryStream;
 
 /**
@@ -44,6 +46,10 @@ public interface CommonOptions {
 
     default boolean ignoreSuppressionAnnotations() {
         return false;
+    }
+
+    default Set<String> preferKeepingExistingSuppression() {
+        return Set.of();
     }
 
     default CommonOptions naivelyCombinedWith(CommonOptions other) {
@@ -69,6 +75,15 @@ public interface CommonOptions {
             @Override
             public boolean ignoreSuppressionAnnotations() {
                 return CommonOptions.this.ignoreSuppressionAnnotations() || other.ignoreSuppressionAnnotations();
+            }
+
+            @Override
+            public Set<String> preferKeepingExistingSuppression() {
+                // Union the two sets when combining
+                return Stream.concat(
+                                CommonOptions.this.preferKeepingExistingSuppression().stream(),
+                                other.preferKeepingExistingSuppression().stream())
+                        .collect(Collectors.toSet());
             }
         };
     }
@@ -99,6 +114,11 @@ public interface CommonOptions {
             @Override
             public boolean ignoreSuppressionAnnotations() {
                 return CommonOptions.this.ignoreSuppressionAnnotations();
+            }
+
+            @Override
+            public Set<String> preferKeepingExistingSuppression() {
+                return CommonOptions.this.preferKeepingExistingSuppression();
             }
         };
     }

--- a/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
+++ b/gradle-suppressible-error-prone/src/test/groovy/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.groovy
@@ -1706,6 +1706,59 @@ class SuppressibleErrorPronePluginIntegrationTest extends ConfigurationCacheSpec
         '''.stripIndent(true)
     }
 
+    def 'errorProneRemoveUnused leaves preferKeepingExistingSuppression checks untouched'() {
+        // language=Java
+        def initialSource = '''
+            package app;
+
+            @SuppressWarnings({"NullAway", "for-rollout:rawtypes"})
+            public final class App {}
+        '''.stripIndent(true)
+        writeJavaSourceFileToSourceSets initialSource
+        when:
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveUnused')
+        then:
+        // language=Java
+        javaSourceIsSyntacticallyEqualTo initialSource
+    }
+
+    def 'errorProneRemoveUnused + errorProneApply respects preferKeepingExistingSuppression'() {
+        given:
+        // language=Gradle
+        buildFile << '''
+            suppressibleErrorProne {
+                preferKeepingExistingSuppression = ["ShouldBePrivate"] as Set
+            }
+        '''.stripIndent(true)
+
+        writeJavaSourceFileToSourceSets '''
+            package app;
+
+            public final class App {
+                @SuppressWarnings("ShouldBePrivate")
+                void fixme(String s) {}
+                
+                void fixme(Integer i) {}
+            }
+        '''.stripIndent(true)
+
+        when: 'ShouldBePrivate is in preferKeepingExistingSuppression'
+        runTasksSuccessfully('compileAllErrorProne', '-PerrorProneRemoveUnused', '-PerrorProneApply=ShouldBePrivate')
+
+        then: 'removeUnused + apply does not fix suppressed node'
+        // language=Java
+        javaSourceIsSyntacticallyEqualTo '''
+            package app;
+
+            public final class App {
+                @SuppressWarnings("ShouldBePrivate")
+                void fixme(String s) {}
+                
+                private void fixme(Integer i) {}
+            }
+        '''.stripIndent(true)
+    }
+
     def 'errorProneRemoveUnused only keeps the closest suppression to a violation'() {
         // language=Java
         writeJavaSourceFileToSourceSets '''

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressionRemover.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/SuppressionRemover.java
@@ -30,9 +30,13 @@ public final class SuppressionRemover {
     // has finished processing.
     private static final Set<CompilationUnitTree> attachedFixes = Collections.newSetFromMap(new WeakHashMap<>());
 
-    public static void removeAllSuppressionsOnErrorprones(
+    public static void removeAllKnownBugcheckerSuppressions(
             ReportedFixCache reportedFixes, CompilationUnitTree unit, VisitorState state) {
         if (attachedFixes.add(unit)) {
+            Set<String> preferKeepingExistingSuppression = state.errorProneOptions()
+                    .getFlags()
+                    .getSetOrEmpty("SuppressibleErrorProne:PreferKeepingExistingSuppression");
+
             new TreePathScanner<Void, Void>() {
                 @SuppressWarnings("for-rollout:VoidUsed")
                 @Override
@@ -41,8 +45,12 @@ public final class SuppressionRemover {
                         TreePath declaration = getCurrentPath().getParentPath().getParentPath();
 
                         reportedFixes.getOrReportNew(
-                                declaration, state, suppression -> !AllErrorprones.allBugcheckerNames(state)
-                                        .contains(suppression));
+                                declaration,
+                                state,
+                                suppression -> !AllErrorprones.allBugcheckerNames(state)
+                                                .contains(SuppressWarningsUtils.stripForRollout(suppression))
+                                        || preferKeepingExistingSuppression.contains(
+                                                SuppressWarningsUtils.stripForRollout(suppression)));
                     }
 
                     return super.visitAnnotation(node, unused);

--- a/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
+++ b/suppressible-error-prone/src/main/java/com/palantir/suppressibleerrorprone/VisitorStateModifications.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
-import one.util.streamex.MoreCollectors;
 
 // CHECKSTYLE:ON
 
@@ -52,7 +51,7 @@ public final class VisitorStateModifications {
         if (modes.contains("RemoveUnused")) {
             // Start by removing all suppressions on error-prones, including rollout and human-made.
             // Then, as we encounter Descriptions without fixes, we add back the closest suppression
-            SuppressionRemover.removeAllSuppressionsOnErrorprones(FIXES, compilationUnit, visitorState);
+            SuppressionRemover.removeAllKnownBugcheckerSuppressions(FIXES, compilationUnit, visitorState);
         }
 
         // If both -PerrorProneSuppress and -PerrorProneApply are used at the same time, for the checks configured as
@@ -67,7 +66,28 @@ public final class VisitorStateModifications {
         boolean checkHasSuggestedFixes = !description.fixes.isEmpty();
 
         if (shouldPreferDefaultSuggestedFixesForThisCheck && checkHasSuggestedFixes) {
-            return description;
+            // If this check is in preferKeepingExistingSuppression AND there's an existing suppression
+            // that will be kept, we should NOT apply the fix because the suppression will remain
+            Set<String> preferKeepingExistingSuppression = visitorState
+                    .errorProneOptions()
+                    .getFlags()
+                    .getSetOrEmpty("SuppressibleErrorProne:PreferKeepingExistingSuppression");
+
+            TreePath pathToActualError =
+                    TreePath.getPath(visitorState.getPath().getCompilationUnit(), description.position.getTree());
+
+            boolean hasExistingSuppressionThatWillBeKept =
+                    preferKeepingExistingSuppression.contains(description.checkName)
+                            && Stream.iterate(
+                                            pathToActualError,
+                                            treePath -> treePath.getParentPath() != null,
+                                            TreePath::getParentPath)
+                                    .anyMatch(path -> suppresses(path, description, visitorState));
+
+            if (!hasExistingSuppressionThatWillBeKept) {
+                return description;
+            }
+            // Fall through to treat it like a regular check (either suppress or return NO_MATCH)
         }
 
         // If the check is a suggestion, we don't want to auto-suppress it, so we return no match (such that it also
@@ -91,17 +111,11 @@ public final class VisitorStateModifications {
         if (firstSuppressibleWhichSuppressesDescription.isPresent() && modes.contains("RemoveUnused")) {
             // In RemoveUnused mode, removeAllSuppressionsOnErrorprones guarantees that a fix must already exist on
             // this suppressible.
-            TreePath declaration = firstSuppressibleWhichSuppressesDescription.get();
-            Set<String> allNames =
-                    AllErrorprones.allNames(visitorState, description.checkName).get();
-            // Use the existing suppression, rather than changing it to the canonical suppression
-            String existingSuppression = AnnotationUtils.annotationStringValues(
-                            SuppressWarningsUtils.getSuppressWarnings(declaration)
-                                    .get())
-                    .filter(suppression -> allNames.contains(SuppressWarningsUtils.stripForRollout(suppression)))
-                    .collect(MoreCollectors.first())
-                    .get();
-            FIXES.getExisting(declaration).addSuppression(existingSuppression);
+            TreePath firstSuppressible = firstSuppressibleWhichSuppressesDescription.get();
+            String existingSuppression =
+                    suppressionsOn(firstSuppressible, description, visitorState).get(0);
+            FIXES.getOrReportNew(firstSuppressible, visitorState, suppression -> true)
+                    .addSuppression(existingSuppression);
             return Description.NO_MATCH;
         }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

FLUP to https://github.com/palantir/suppressible-error-prone/pull/278

Our mental model of a BugChecker is 

- Uses the suppression mechanisms built into error-prone (e.g. not descending into the BugChecker at all, or using `SuppressibleTreePathScanner`)
- A fix is always preferable to a suppression

Some checkers break this
- RemoveUnused was overzealously removing instances of StrictUnusedVariable and NullAway. This is because they roll their own suppression checking, which don't respect -XoptIgnoreSuppressionAnnotations
- RemoveUnused + Apply mode was autofixing suppressed instances of [SafeLoggingPropagation](https://github.com/palantir/baseline-error-prone/blob/develop/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java) by adding `@DoNotLog` and `@Unsafe`. However, these human-added suppressions are vetted and deliberate. The autofix downgrades the log-safety of the affected methods, which is undesireable

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Add the `SuppressibleErrorProne:PreferKeepingExistingSuppression` option, so removeUnused mode will shunt 
- Checks which behave in weird ways
- Checks whose autofixes aren't desirable (should be the minority)

==COMMIT_MSG==
Add the `preferKeepingExistingSuppression` extension option to shunt removeUnused mode for non-standard checks
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

If we want to be extra safe, we can make `removeUnused` only remove rollout suppressions. This should be a small code change.

I am leaning towards preferring autofixes as the default. We should roll this out with a background excavator to discover more rogue/undesireable fixes before integrating this into our upgrade infrastructure.