### PR TITLE
Wire up `gw publish` to `artifact-transforms:publish`

### DIFF
--- a/gradle-suppressible-error-prone/build.gradle
+++ b/gradle-suppressible-error-prone/build.gradle
@@ -64,3 +64,8 @@ moduleJvmArgs {
     // Need so that debugging testkit gradle runs with configuration cache works
     opens 'java.base/java.util', 'java.base/java.lang.invoke'
 }
+
+// TEMPHACK(okelvin): until we figure out a first-class way to wire up publishing for included builds
+tasks.named('publish').configure {
+    dependsOn gradle.includedBuild('artifact-transforms').task(':publish')
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We attempted to get `artifact-transforms` to publish in https://github.com/palantir/suppressible-error-prone/pull/357. We got one thing wrong — running `gw publish` in the root project does not run `publish` in included builds. 

## After this PR

Do some janky manual wiring until we figure out a first class (or at least nicer) way to support this. 

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Wire up `gw publish` to `artifact-transforms:publish`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Maybe we really need a way to test publishing

Also this janky fix doesn't work for `pTML` and probably other tasks you'd expect it to work for. 