### PR TITLE
Bump error-prone to 2.49.0

### DIFF
--- a/versions.lock
+++ b/versions.lock
@@ -12,15 +12,15 @@ com.google.auto.service:auto-service-annotations:1.1.1 (2 constraints: 8a20341c)
 
 com.google.auto.value:auto-value-annotations:1.11.0 (4 constraints: ee3fa36e)
 
-com.google.errorprone:error_prone_annotation:2.46.0 (4 constraints: 0d3e3762)
+com.google.errorprone:error_prone_annotation:2.49.0 (4 constraints: 193e1266)
 
-com.google.errorprone:error_prone_annotations:2.46.0 (6 constraints: ce5de693)
+com.google.errorprone:error_prone_annotations:2.49.0 (6 constraints: d75d2198)
 
-com.google.errorprone:error_prone_check_api:2.46.0 (3 constraints: f72a565c)
+com.google.errorprone:error_prone_check_api:2.49.0 (3 constraints: 002b515e)
 
-com.google.errorprone:error_prone_core:2.46.0 (1 constraints: 3e054d3b)
+com.google.errorprone:error_prone_core:2.49.0 (1 constraints: 4105563b)
 
-com.google.googlejavaformat:google-java-format:1.27.0 (2 constraints: b6258eff)
+com.google.googlejavaformat:google-java-format:1.35.0 (2 constraints: b42552ff)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
@@ -30,9 +30,9 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 
 com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
-com.google.protobuf:protobuf-java:3.25.5 (1 constraints: 2c1160c9)
+com.google.protobuf:protobuf-java:4.33.2 (1 constraints: 291161c9)
 
-com.palantir.gradle.utils:environment-variables:0.23.0 (1 constraints: 9a07ea7d)
+com.palantir.gradle.utils:environment-variables:0.23.0 (1 constraints: 3705303b)
 
 io.github.eisop:dataflow-errorprone:3.41.0-eisop1 (3 constraints: 3e40ddde)
 
@@ -76,7 +76,7 @@ com.fasterxml.woodstox:woodstox-core:7.1.1 (1 constraints: 3d174926)
 
 com.google.code.findbugs:jsr305:3.0.2 (1 constraints: d8120c26)
 
-com.google.errorprone:error_prone_test_helpers:2.46.0 (1 constraints: 3e054d3b)
+com.google.errorprone:error_prone_test_helpers:2.49.0 (1 constraints: 4105563b)
 
 com.google.jimfs:jimfs:1.3.0 (1 constraints: 5a141061)
 

--- a/versions.props
+++ b/versions.props
@@ -18,5 +18,5 @@ one.util:streamex = 0.8.4
 # We want to avoid upgrading errorprone automatically as it will bring with it new checks.
 # TODO(callumr): Work out some way to *test* against latest errorprone as well as this minimum bound but
 #                keep the dependency low so suppressible-error-prone upgrades do not get blocked.
-com.google.errorprone:* = 2.46.0
+com.google.errorprone:* = 2.49.0
 # dependency-upgrader:ON


### PR DESCRIPTION
Bumps `com.google.errorprone:*` from 2.46.0 to 2.49.0.

## Possible downsides?