### PR TITLE
Bump `gradle-plugin-testing` to 0.72.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0'
-        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.25.0'
+        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.72.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.26.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.17.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:3.6.0'

--- a/versions.lock
+++ b/versions.lock
@@ -84,17 +84,21 @@ com.google.truth:truth:1.4.0 (2 constraints: 72265a6a)
 
 com.netflix.nebula:nebula-test:10.6.2 (2 constraints: d61de72d)
 
-com.palantir.gradle.plugintesting:configuration-cache-spec:0.25.0 (1 constraints: 9b07e57d)
+com.palantir.gradle.plugintesting:configuration-cache-spec:0.72.0 (1 constraints: 3b05413b)
 
-com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.25.0 (1 constraints: 3905363b)
+com.palantir.gradle.plugintesting:discover-tests-cli:0.72.0 (1 constraints: 3b05413b)
 
-com.palantir.gradle.plugintesting:plugin-testing-core:0.25.0 (1 constraints: 3905363b)
+com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.72.0 (1 constraints: 3b05413b)
+
+com.palantir.gradle.plugintesting:plugin-testing-core:0.72.0 (2 constraints: 121f788d)
 
 com.palantir.javaformat:palantir-java-format:2.81.0 (1 constraints: 3d054e3b)
 
 com.palantir.javaformat:palantir-java-format-spi:2.81.0 (1 constraints: 0e132f39)
 
-commons-io:commons-io:2.20.0 (2 constraints: 101f108c)
+commons-io:commons-io:2.22.0 (2 constraints: 0a1fff8b)
+
+info.picocli:picocli:4.7.7 (1 constraints: 2816dcdd)
 
 junit:junit:4.13.2 (4 constraints: 873fce86)
 
@@ -114,7 +118,7 @@ org.hamcrest:hamcrest-core:2.2 (3 constraints: 84262b80)
 
 org.hamcrest:hamcrest-library:2.2 (1 constraints: fc138e38)
 
-org.jetbrains:annotations:26.0.2 (1 constraints: d9190fdf)
+org.jetbrains:annotations:26.1.0 (1 constraints: d81910df)
 
 org.junit.jupiter:junit-jupiter:6.0.1 (1 constraints: 48070970)
 
@@ -128,7 +132,7 @@ org.junit.platform:junit-platform-commons:6.0.1 (2 constraints: d520474a)
 
 org.junit.platform:junit-platform-engine:6.0.1 (3 constraints: 22304b56)
 
-org.junit.platform:junit-platform-launcher:6.0.1 (1 constraints: 09050a36)
+org.junit.platform:junit-platform-launcher:6.0.1 (2 constraints: 571b2362)
 
 org.objenesis:objenesis:2.4 (1 constraints: ea0c8c0a)
 

--- a/versions.props
+++ b/versions.props
@@ -4,7 +4,6 @@ com.google.auto.service:auto-service = 1.1.1
 com.google.guava:guava = 33.5.0-jre
 com.netflix.nebula:nebula-test = 10.6.2
 com.palantir.gradle.utils:environment-variables = 0.20.0
-com.palantir.gradle.plugintesting:* = 0.11.0
 com.palantir.javaformat:* = 2.81.0
 commons-io:commons-io = 2.20.0
 net.ltgt.gradle:gradle-errorprone-plugin = 4.3.0


### PR DESCRIPTION
## Before this PR

Excavator's "Apply Gradle Plugin Testing Helper" check (`roomba/gradle-plugin-test-helper`) was failing to bump `com.palantir.gradle.plugintesting:gradle-plugin-testing`. The most recent attempt (#362, closed) bumped the buildscript classpath but did **not** regenerate `versions.lock`, so the plugin-injected test dependencies could not be resolved:

```
> Could not resolve com.palantir.gradle.plugintesting:plugin-testing-core:0.69.0.
  > Cannot find a version of 'plugin-testing-core' that satisfies the version constraints:
      Constraint path: ... 'plugin-testing-core:{strictly 0.57.0}' because of the following reason: Locked by versions.lock
```

The repo also carried a stale `versions.props` pin `com.palantir.gradle.plugintesting:* = 0.11.0` that no longer matched reality — the artifact versions are driven by the buildscript plugin (then `0.25.0`), so the pin was overridden and misleading.

## After this PR

- Bump the `gradle-plugin-testing` buildscript classpath `0.25.0` → `0.72.0` and regenerate `versions.lock` so all `com.palantir.gradle.plugintesting:*` artifacts resolve consistently at `0.72.0`.
- Remove the redundant/stale `com.palantir.gradle.plugintesting:* = 0.11.0` pin from `versions.props`; the version is dictated by the applied plugin.

No source changes are needed — this repo does not use the now-deprecated `PropertiesFile.appendProperty` API.

## Possible downsides?

None expected. This is a build-infrastructure-only change (buildscript classpath + test dependencies); the published plugin artifact is unaffected. Verified locally with `./gradlew format compileAllErrorProne checkstyleMain checkstyleTest verifyLocks`.