### PR TITLE
Bump Error Prone to 2.49.0

### DIFF
--- a/changelog/@unreleased/pr-418.v2.yml
+++ b/changelog/@unreleased/pr-418.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Updated Error Prone dependencies to 2.49.0.
+  links:
+  - https://github.com/palantir/suppressible-error-prone/pull/418

--- a/versions.lock
+++ b/versions.lock
@@ -12,15 +12,15 @@ com.google.auto.service:auto-service-annotations:1.1.1 (2 constraints: 8a20341c)
 
 com.google.auto.value:auto-value-annotations:1.11.0 (4 constraints: ee3fa36e)
 
-com.google.errorprone:error_prone_annotation:2.46.0 (4 constraints: 0d3e3762)
+com.google.errorprone:error_prone_annotation:2.49.0 (4 constraints: 193e1266)
 
-com.google.errorprone:error_prone_annotations:2.46.0 (6 constraints: ce5de693)
+com.google.errorprone:error_prone_annotations:2.49.0 (6 constraints: d75d2198)
 
-com.google.errorprone:error_prone_check_api:2.46.0 (3 constraints: f72a565c)
+com.google.errorprone:error_prone_check_api:2.49.0 (3 constraints: 002b515e)
 
-com.google.errorprone:error_prone_core:2.46.0 (1 constraints: 3e054d3b)
+com.google.errorprone:error_prone_core:2.49.0 (1 constraints: 4105563b)
 
-com.google.googlejavaformat:google-java-format:1.27.0 (2 constraints: b6258eff)
+com.google.googlejavaformat:google-java-format:1.35.0 (2 constraints: b42552ff)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
@@ -30,7 +30,7 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 
 com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
-com.google.protobuf:protobuf-java:3.25.5 (1 constraints: 2c1160c9)
+com.google.protobuf:protobuf-java:4.33.2 (1 constraints: 291161c9)
 
 com.palantir.gradle.utils:environment-variables:0.23.0 (1 constraints: 9a07ea7d)
 
@@ -40,7 +40,7 @@ io.github.java-diff-utils:java-diff-utils:4.12 (1 constraints: b412c908)
 
 javax.inject:javax.inject:1 (2 constraints: 51221d52)
 
-net.ltgt.gradle:gradle-errorprone-plugin:5.0.0 (1 constraints: 07050436)
+net.ltgt.gradle:gradle-errorprone-plugin:5.1.0 (1 constraints: 08050736)
 
 one.util:streamex:0.8.4 (2 constraints: cd2005f2)
 
@@ -76,7 +76,7 @@ com.fasterxml.woodstox:woodstox-core:7.1.1 (1 constraints: 3d174926)
 
 com.google.code.findbugs:jsr305:3.0.2 (1 constraints: d8120c26)
 
-com.google.errorprone:error_prone_test_helpers:2.46.0 (1 constraints: 3e054d3b)
+com.google.errorprone:error_prone_test_helpers:2.49.0 (1 constraints: 4105563b)
 
 com.google.jimfs:jimfs:1.3.0 (1 constraints: 5a141061)
 

--- a/versions.props
+++ b/versions.props
@@ -7,7 +7,7 @@ com.palantir.gradle.utils:environment-variables = 0.23.0
 com.palantir.gradle.consistentversions:gradle-consistent-versions = 3.13.0
 com.palantir.javaformat:* = 2.89.0
 commons-io:commons-io = 2.21.0
-net.ltgt.gradle:gradle-errorprone-plugin = 5.0.0
+net.ltgt.gradle:gradle-errorprone-plugin = 5.1.0
 org.assertj:assertj-core = 3.27.7
 org.junit.jupiter:* = 6.0.3
 org.junit.platform:* = 6.0.3
@@ -18,5 +18,5 @@ one.util:streamex = 0.8.4
 # We want to avoid upgrading errorprone automatically as it will bring with it new checks.
 # TODO(callumr): Work out some way to *test* against latest errorprone as well as this minimum bound but
 #                keep the dependency low so suppressible-error-prone upgrades do not get blocked.
-com.google.errorprone:* = 2.46.0
+com.google.errorprone:* = 2.49.0
 # dependency-upgrader:ON


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`suppressible-error-prone` was still testing against Error Prone 2.46.0 and `gradle-errorprone-plugin` 5.0.0.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Bump Error Prone to 2.49.0

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->